### PR TITLE
added job timeouts

### DIFF
--- a/.github/workflows/hdtn_test_workflow_windows.yml
+++ b/.github/workflows/hdtn_test_workflow_windows.yml
@@ -6,6 +6,8 @@ jobs:
   windows-2022-x64-test:
     runs-on: windows-2022
 
+    timeout-minutes: 60
+
     steps:
       - uses: actions/checkout@v3
 
@@ -25,6 +27,8 @@ jobs:
 
   windows-2019-x64-test:
     runs-on: windows-2019
+
+    timeout-minutes: 60
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
This workflow has been identified as a large consumer of NASA's allotted 2,000 action minutes and will need to be limited.
@darith27 @rubioJeffery @TKantz @nadiakortas @briantomko 