### PR TITLE
Docs for LTP over UDP components

### DIFF
--- a/common/ltp/include/LtpUdpEngine.h
+++ b/common/ltp/include/LtpUdpEngine.h
@@ -37,6 +37,16 @@ class CLASS_VISIBILITY_LTP_LIB LtpUdpEngine : public LtpEngine {
 private:
     LtpUdpEngine() = delete;
 public:
+    /**
+     * Preallocate M_NUM_CIRCULAR_BUFFER_VECTORS receive buffers, each with a size of maxUdpRxPacketSizeBytes.
+     * If the engine is configured for more than one packet per system call, initialize the batch sender instance passing LtpUdpEngine::OnSentPacketsCallback as the send callback.
+     * @param ioServiceUdpRef I/O execution context reference, typically supplied by the associated LtpUdpEngineManager.
+     * @param udpSocketRef Our managed UDP socket, typically supplied by the associated LtpUdpEngineManager.
+     * @param engineIndexForEncodingIntoRandomSessionNumber The engine index.
+     * @param remoteEndpoint The remote UDP endpoint.
+     * @param maxUdpRxPacketSizeBytes The maximum UDP packet size in bytes.
+     * @param ltpRxOrTxCfg The engine config.
+     */
     LTP_LIB_EXPORT LtpUdpEngine(boost::asio::io_service & ioServiceUdpRef,
         boost::asio::ip::udp::socket & udpSocketRef,
         const uint8_t engineIndexForEncodingIntoRandomSessionNumber, 
@@ -44,61 +54,169 @@ public:
         const uint64_t maxUdpRxPacketSizeBytes,
         const LtpEngineConfig& ltpRxOrTxCfg);
 
+    /// Stat logging
     LTP_LIB_EXPORT virtual ~LtpUdpEngine() override;
-
+    
+    /** Initiate an engine reset (thread-safe).
+     *
+     * Initiates an asynchronous call to LtpUdpEngine::Reset() to perform a reset.
+     * The calling thread blocks until the request is resolved.
+     */
     LTP_LIB_EXPORT void Reset_ThreadSafe_Blocking();
+    
+    /** Perform engine reset.
+     *
+     * Calls LtpEngine::Reset() to reset the underlying LTP engine, then clear tracked stats.
+     */
     LTP_LIB_EXPORT virtual void Reset() override;
     
+    /**
+     * If the receive buffers are full, the packet is dropped.
+     * Else, swaps in the packet to the receive buffer and calls LtpEngine::PacketIn_ThreadSafe() to forward to the underlying LtpEngine for processing.
+     * packetIn_thenSwappedForAnotherSameSizeVector holds the entire receive buffer, only the first 'size' bytes belong in the current packet and are
+     * therefore safe to read, any bytes that follow may contain partial data from previously processed packets and should be treated as garbage values.
+     * @param packetIn_thenSwappedForAnotherSameSizeVector The packet to transmit.
+     * @param size The size of the packet.
+     * @post The argument to packetIn_thenSwappedForAnotherSameSizeVector is swapped with a potentially dirty buffer of an already-processed packet and is ready to
+     * be reused as the receive buffer for the next read operation (see above how to handle dirty buffers).
+     */
     LTP_LIB_EXPORT void PostPacketFromManager_ThreadSafe(std::vector<uint8_t> & packetIn_thenSwappedForAnotherSameSizeVector, std::size_t size);
 
+    /** Initiate a request to set the UDP endpoint (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpUdpEngine::SetEndpoint().
+     * @param remoteEndpoint The UDP endpoint to set.
+     */
     LTP_LIB_EXPORT void SetEndpoint_ThreadSafe(const boost::asio::ip::udp::endpoint& remoteEndpoint);
+    
+    /** Initiate a request to set the UDP endpoint (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpUdpEngine::SetEndpoint().
+     * @param remoteHostname The remote host.
+     * @param remotePort The remote port.
+     */
     LTP_LIB_EXPORT void SetEndpoint_ThreadSafe(const std::string& remoteHostname, const uint16_t remotePort);
 
 private:
+    /** Handle the completion of a receive buffer processing operation.
+     *
+     * Invoked by the underlying LTP engine when a received packet is fully processed.
+     * Completes the processing by committing the read to the circular index buffer.
+     * @param success Whether the processing was successful.
+     */
     LTP_LIB_NO_EXPORT virtual void PacketInFullyProcessedCallback(bool success) override;
+    
+    /** Initiate a UDP send operation for a single packet. //TODO: Docs, complete
+     *
+     * Initiates an asynchronous send operation with LtpUdpEngine::HandleUdpSend() as a completion handler.
+     * @param constBufferVec
+     * @param underlyingDataToDeleteOnSentCallback
+     * @param underlyingCsDataToDeleteOnSentCallback
+     * @post The arguments to underlyingDataToDeleteOnSentCallback and underlyingCsDataToDeleteOnSentCallback are left in a moved-from state.
+     */
     LTP_LIB_NO_EXPORT virtual void SendPacket(std::vector<boost::asio::const_buffer> & constBufferVec,
         std::shared_ptr<std::vector<std::vector<uint8_t> > > & underlyingDataToDeleteOnSentCallback,
         std::shared_ptr<LtpClientServiceDataToSend>& underlyingCsDataToDeleteOnSentCallback) override;
+    
+    /** Handle a UDP send operation. //TODO: Docs, complete
+     *
+     * Invoked for single-packet-per-system-call send operations.
+     * If successful, signals the underlying LtpEngine that a system call has completed with OnSendPacketsSystemCallCompleted_ThreadSafe().
+     * @param underlyingDataToDeleteOnSentCallback
+     * @param underlyingCsDataToDeleteOnSentCallback
+     * @param error The error code.
+     * @param bytes_transferred The number of bytes sent.
+     */
     LTP_LIB_NO_EXPORT void HandleUdpSend(std::shared_ptr<std::vector<std::vector<uint8_t> > > & underlyingDataToDeleteOnSentCallback,
         std::shared_ptr<LtpClientServiceDataToSend>& underlyingCsDataToDeleteOnSentCallback,
         const boost::system::error_code& error, std::size_t bytes_transferred);
+    
+    /** Initiate a batch UDP send operation. //TODO: Docs, complete
+     *
+     * Queues the packets for a batch send operation with UdpBatchSender::QueueSendPacketsOperation_ThreadSafe().
+     * The batch sender instance is configured to use LtpUdpEngine::OnSentPacketsCallback() as a completion handler which will be called once the operation has completed.
+     * @param constBufferVecs
+     * @param underlyingDataToDeleteOnSentCallback
+     * @param underlyingCsDataToDeleteOnSentCallback
+     */
     LTP_LIB_NO_EXPORT virtual void SendPackets(std::vector<std::vector<boost::asio::const_buffer> >& constBufferVecs,
         std::vector<std::shared_ptr<std::vector<std::vector<uint8_t> > > >& underlyingDataToDeleteOnSentCallback,
         std::vector<std::shared_ptr<LtpClientServiceDataToSend> >& underlyingCsDataToDeleteOnSentCallback) override;
+    
+    /** Handle a batch UDP send operation. //TODO: Docs, complete
+     *
+     * Invoked for batch send operations.
+     * If successful, signals the underlying LtpEngine that a system call has completed with OnSendPacketsSystemCallCompleted_ThreadSafe().
+     * @param success Whether the operation was successful.
+     * @param constBufferVecs
+     * @param underlyingDataToDeleteOnSentCallback
+     * @param underlyingCsDataToDeleteOnSentCallback
+     */
     LTP_LIB_NO_EXPORT void OnSentPacketsCallback(bool success, std::vector<std::vector<boost::asio::const_buffer> >& constBufferVecs,
         std::vector<std::shared_ptr<std::vector<std::vector<uint8_t> > > >& underlyingDataToDeleteOnSentCallback,
         std::vector<std::shared_ptr<LtpClientServiceDataToSend> >& underlyingCsDataToDeleteOnSentCallback);
+    
+    /** Set the UDP endpoint.
+     *
+     * If the engine is configured for more than one packet per system call, also sets the endpoint for the batch sender instance.
+     * @param remoteEndpoint The UDP endpoint to set.
+     */
     LTP_LIB_NO_EXPORT void SetEndpoint(const boost::asio::ip::udp::endpoint& remoteEndpoint);
+    
+    /** Set the UDP endpoint.
+     *
+     * Tries to synchronously resolve the remote endpoint from the given host/port pair, if successful calls LtpUdpEngine::SetEndpoint(resolved_endpoint).
+     * @param remoteHostname The remote host.
+     * @param remotePort The remote port.
+     * @post If the resolve operation fails, the UDP endpoint is NOT set and the operation is silently ignored.
+     */
     LTP_LIB_NO_EXPORT void SetEndpoint(const std::string& remoteHostname, const uint16_t remotePort);
     
 
     
+    /// Batch sender instance
     UdpBatchSender m_udpBatchSenderConnected;
+    /// I/O execution context reference, typically supplied by the associated LtpUdpEngineManager
     boost::asio::io_service & m_ioServiceUdpRef;
+    /// Our managed UDP socket, typically supplied by the associated LtpUdpEngineManager
     boost::asio::ip::udp::socket & m_udpSocketRef;
+    /// Remote UDP endpoint
     boost::asio::ip::udp::endpoint m_remoteEndpoint;
-    
 
+    /// Number of receive buffers
     const unsigned int M_NUM_CIRCULAR_BUFFER_VECTORS;
+    /// Circular index buffer, used to index the circular vector of receive buffers
     CircularIndexBufferSingleProducerSingleConsumerConfigurable m_circularIndexBuffer;
+    /// Circular vector of receive buffers
     std::vector<std::vector<boost::uint8_t> > m_udpReceiveBuffersCbVec;
 
+    /// Logger flag, set to False to log a notice on the SINGLE next increment of m_countCircularBufferOverruns
     bool m_printedCbTooSmallNotice;
 
     //for safe unit test resets
+    /// Whether an engine reset is currently in progress
     volatile bool m_resetInProgress;
+    /// Engine reset mutex
     boost::mutex m_resetMutex;
+    /// Engine reset condition variable
     boost::condition_variable m_resetConditionVariable;
 
 public:
+    /// Total number of initiated send operations
     volatile uint64_t m_countAsyncSendCalls;
+    /// Total number of send operation completion handler invocations, indicates the number of completed send operations
     volatile uint64_t m_countAsyncSendCallbackCalls; //same as udp packets sent
+    /// Total number of initiated batch send operations through m_udpBatchSenderConnected
     volatile uint64_t m_countBatchSendCalls;
+    /// Total number of batch send operation completion handler invocations, indicates the number of completed batch send operations
     volatile uint64_t m_countBatchSendCallbackCalls;
+    /// Total number of packets actually sent across batch send operations
     volatile uint64_t m_countBatchUdpPacketsSent;
     //total udp packets sent is m_countAsyncSendCallbackCalls + m_countBatchUdpPacketsSent
 
+    /// Total number of requests attempted to queue a packet for transmission while transmission buffers were full
     uint64_t m_countCircularBufferOverruns;
+    /// Total number of packets received, includes number of dropped packets due to receive buffers being full
     uint64_t m_countUdpPacketsReceived;
 };
 

--- a/common/ltp/include/LtpUdpEngineManager.h
+++ b/common/ltp/include/LtpUdpEngineManager.h
@@ -37,8 +37,18 @@
 class LtpUdpEngineManager : private boost::noncopyable {
 private:
     LtpUdpEngineManager() = delete;
+    
+    /**
+     * Bind I/O components to m_ioServiceUdp.
+     * Preallocate space in m_vecEngineIndexToLtpUdpEngineTransmitterPtr to cover the addressing space for indexing by engine index (2 ^ [8 engine index bytes]).
+     * Set m_readyToForward to False to initialize engine manager as idle.
+     * If autoStart is set to True, call LtpUdpEngineManager::StartIfNotAlreadyRunning() to start the engine manager.
+     * @param myBoundUdpPort Our UDP port.
+     * @param autoStart Whether the engine manager should start automatically on construction.
+     */
     LTP_LIB_EXPORT LtpUdpEngineManager(const uint16_t myBoundUdpPort, const bool autoStart); //LtpUdpEngineManager can only be created by the GetOrCreateInstance() function
 public:
+    /// Call LtpUdpEngineManager::Stop() to release managed resources
     LTP_LIB_EXPORT ~LtpUdpEngineManager();
 
     /** First bind the LTP UDP socket to myBoundUdpPort from the constructor.
@@ -62,48 +72,160 @@ public:
      */
     LTP_LIB_EXPORT bool AddLtpUdpEngine(const LtpEngineConfig& ltpRxOrTxCfg);
 
+    /** Find registered engine by engine ID.
+     *
+     * @param remoteEngineId The engine ID.
+     * @param isInduct Whether to search through inducts (or outducts).
+     * @return A pointer to the engine if exists and is of the correct type indicated by isInduct, or NULL otherwise.
+     */
     LTP_LIB_EXPORT LtpUdpEngine * GetLtpUdpEnginePtrByRemoteEngineId(const uint64_t remoteEngineId, const bool isInduct);
-    LTP_LIB_EXPORT void RemoveLtpUdpEngineByRemoteEngineId_ThreadSafe(const uint64_t remoteEngineId, const bool isInduct, const boost::function<void()> & callback);
-    LTP_LIB_EXPORT void RemoveLtpUdpEngineByRemoteEngineId_NotThreadSafe(const uint64_t remoteEngineId, const bool isInduct, const boost::function<void()> & callback);
-    LTP_LIB_EXPORT void Stop();
-    LTP_LIB_EXPORT void DoUdpShutdown();
     
+    /** Initiate a request to remove a registered engine by engine ID (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpUdpEngineManager::RemoveLtpUdpEngineByRemoteEngineId_NotThreadSafe().
+     * @param remoteEngineId The engine ID.
+     * @param isInduct Whether to search through inducts (or outducts).
+     * @param callback The callback to invoke on completion.
+     */
+    LTP_LIB_EXPORT void RemoveLtpUdpEngineByRemoteEngineId_ThreadSafe(const uint64_t remoteEngineId, const bool isInduct, const boost::function<void()> & callback);
+    
+    /** Remove a registered engine by engine ID.
+     *
+     * Removes the registered engine if exists and is of the correct type indicated by isInduct.
+     * On removal, invalidates the cache if appropriate, then cleans up the remaining reference in m_vecEngineIndexToLtpUdpEngineTransmitterPtr.
+     * Invokes callback on completion.
+     * @param remoteEngineId The engine ID.
+     * @param isInduct Whether to search through inducts (or outducts).
+     * @param callback The callback to invoke on completion.
+     * @post The necessary state held by the engine manager on the to-be-removed engine will have been cleaned up by the time callback is invoked.
+     */
+    LTP_LIB_EXPORT void RemoveLtpUdpEngineByRemoteEngineId_NotThreadSafe(const uint64_t remoteEngineId, const bool isInduct, const boost::function<void()> & callback);
+    
+    /** Perform engine manager shutdown.
+     *
+     * Initiates an asynchronous call to LtpUdpEngineManager::DoUdpShutdown() to release UDP resources, then releases all underlying I/O resources.
+     * @post The object is ready to be reused after the next successful call to LtpUdpEngineManager::StartIfNotAlreadyRunning().
+     */
+    LTP_LIB_EXPORT void Stop();
+   
+    /** Perform engine manager shutdown.
+     *
+     * Stops timers, closes managed socket, sets engine manager to idle, clears registered engines and invalidates cache.
+     * @post The LTP resources are ready to be reused, but the engine manager will remain in the running state until the next call to LtpUdpEngineManager::Stop().
+     */
+    LTP_LIB_EXPORT void DoUdpShutdown();
+
+    /** Query whether the engine manager should be considered operational.
+     *
+     * @return True if the engine manager is marked as operational, or False otherwise.
+     */
     LTP_LIB_EXPORT bool ReadyToForward();
 private:
+    /** Start the receive loop for the remote endpoint to receive from.
+     *
+     * Initiates an asynchronous receive operation with LtpUdpEngineManager::HandleUdpReceive() as a completion handler.
+     */
     LTP_LIB_NO_EXPORT void StartUdpReceive();
+    
+    /** Handle a UDP receive operation.
+     *
+     * If a fatal error occurred during the receive operation, returns immediately letting m_ioServiceUdp run out of work and leaving the engine manager in an idle state.
+     * In case of a recoverable error, the engine manager is set to idle, a link-down event is emitted to the underlying LtpUdpEngine with PostExternalLinkDownEvent_ThreadSafe(),
+     * and to retry after a specified duration, the socket error timer is started asynchronously with LtpUdpEngineManager::OnRetryAfterSocketError_TimerExpired() as a completion handler.
+     *
+     * Attempts to parse the start an LTP header to get the session originator and session number, if packet is malformed it gets dropped and the receive loop starts again.
+     * Parses the direction of the packet with Ltp::GetMessageDirectionFromSegmentFlags().
+     * 1. When (sender -> receiver), we have received a message type that only travels from an outduct (sender) to an induct (receiver),
+     * the session originator value can be used directly to search through the cache or registered inducts to access the referenced engine.
+     * 2. When (receiver -> sender), we have received a message type that only travels from an induct (receiver) to an outduct (sender),
+     * the session originator value is our engine ID, to get a proper identifier we can use we need to feed the session number to LtpRandomNumberGenerator::GetEngineIndexFromRandomSessionNumber(),
+     * the returned engine index can then be used directly to index the outduct pointer vector to access the referenced engine.
+     *
+     * On successful processing, signals the underlying LtpUdpEngine that a packet has been received with PostPacketFromManager_ThreadSafe(),
+     * then calls LtpUdpEngineManager::StartUdpReceive() to achieve a receive loop.
+     * @param error The error code.
+     * @param bytesTransferred The number of bytes received.
+     */
     LTP_LIB_NO_EXPORT void HandleUdpReceive(const boost::system::error_code & error, std::size_t bytesTransferred);
+    
+    /** Handle socket error retry timer expiry.
+     *
+     * If the expiry occurred due to the timer being manually cancelled, returns immediately.
+     * Else, starts the restore from quarantine timer asynchronously with LtpUdpEngineManager::SocketRestored_TimerExpired(),
+     * then calls LtpUdpEngineManager::StartUdpReceive() to try and resume the receive loop.
+     * @param e The error code.
+     */
     LTP_LIB_NO_EXPORT void OnRetryAfterSocketError_TimerExpired(const boost::system::error_code& e);
+    
+    /** Handle restore from quarantine timer expiry.
+     *
+     * If the expiry occurred due to the timer being manually cancelled, returns immediately.
+     * Else, this indicates that the engine has not experienced any socket errors and has been running normally for the duration the timer was active
+     * and can now safely be considered operational and marked as such for external services to then be able to query and resume their own operations.
+     * @param e The error code.
+     */
     LTP_LIB_NO_EXPORT void SocketRestored_TimerExpired(const boost::system::error_code& e);
 public:
+    /** Get or create an engine manager instance.
+     *
+     * @param myBoundUdpPort The UDP port already managed or to-be-bound by the returned engine manager instance.
+     * @param autoStart Whether a new instance should be automatically started on construction, does NOT affect existing instances.
+     * @return A shared pointer to the existing or newly-created engien manager instance.
+     */
     LTP_LIB_EXPORT static std::shared_ptr<LtpUdpEngineManager> GetOrCreateInstance(const uint16_t myBoundUdpPort, const bool autoStart);
+    
+    /** Set the maximum UDP packet size in bytes across all registered engines.
+     *
+     * Needs to be called at least once in the lifetime of the program before starting any external I/O.
+     * @param maxUdpRxPacketSizeBytesForAllLtp The maximum UDP packet size in bytes to set.
+     */
     LTP_LIB_EXPORT static void SetMaxUdpRxPacketSizeBytesForAllLtp(const uint64_t maxUdpRxPacketSizeBytesForAllLtp);
 private:
-    //LtpUdpEngineManager(); 
+    //LtpUdpEngineManager();
+    /// Registered engine managers, mapped by bound port
     static std::map<uint16_t, std::weak_ptr<LtpUdpEngineManager> > m_staticMapBoundPortToLtpUdpEngineManagerPtr;
+    /// Engine manger registry mutex
     static boost::mutex m_staticMutex;
+    /// Maximum UDP packet size in bytes, applies to all registered engines
     static uint64_t M_STATIC_MAX_UDP_RX_PACKET_SIZE_BYTES_FOR_ALL_LTP_UDP_ENGINES;
     
 
-
+    /// Our managed UDP socket port, if the port number 0 the socket is bound to a random ephemeral port
     const uint16_t M_MY_BOUND_UDP_PORT;
+    /// I/O execution context
     boost::asio::io_service m_ioServiceUdp;
+    /// UDP endpoint resolver
     boost::asio::ip::udp::resolver m_resolver;
+    /// Our managed UDP socket
     boost::asio::ip::udp::socket m_udpSocket;
+    
+    /// Socket error retry timer, the time to wait before retrying failed operation
     boost::asio::deadline_timer m_retryAfterSocketErrorTimer;
+    /// Socket restore from quarantine timer, the duration without experiencing socket errors required before the engine manager is marked as operational
     boost::asio::deadline_timer m_socketRestoredTimer;
+    /// ...
     boost::asio::ip::udp::endpoint m_udpDestinationResolvedEndpointDataSourceToDataSink;
+    /// Thread that invokes m_ioServiceUdp.run()
     std::unique_ptr<boost::thread> m_ioServiceUdpThreadPtr;
 
     
+    /// Packet receive buffer
     std::vector<boost::uint8_t> m_udpReceiveBuffer;
+    /// Remote UDP endpoint to receive from
     boost::asio::ip::udp::endpoint m_remoteEndpointReceived;
     //std::map<std::pair<uint64_t, bool>, std::unique_ptr<LtpUdpEngine> > m_mapSessionOriginatorEngineIdPlusIsInductToLtpUdpEnginePtr;
+    /// Registered inducts, mapped by engine ID
     std::map<uint64_t, LtpUdpEngine> m_mapRemoteEngineIdToLtpUdpEngineReceiver; //inducts (differentiate by remote engine id using this map)
+    /// Cached iterator of induct, references m_mapRemoteEngineIdToLtpUdpEngineReceiver, can be invalid/stale do check before use
     std::map<uint64_t, LtpUdpEngine>::iterator m_cachedItRemoteEngineIdToLtpUdpEngineReceiver;
+    /// Registered outducts, mapped by engine ID
     std::map<uint64_t, LtpUdpEngine> m_mapRemoteEngineIdToLtpUdpEngineTransmitter; //outducts (differentiate by engine index encoded into the session number, cannot use this map)
+    /// Registered engines bound to our port, indexed by engine index, the index comes from parsing the session number with LtpRandomNumberGenerator::GetEngineIndexFromRandomSessionNumber()
     std::vector<LtpUdpEngine*> m_vecEngineIndexToLtpUdpEngineTransmitterPtr;
+    /// Engine index to assign to the next registered outduct
     unsigned int m_nextEngineIndex;
 
+    /// Whether the engine manager should currently be considered operational
     volatile bool m_readyToForward;
 public:
 };

--- a/common/util/include/CircularIndexBufferSingleProducerSingleConsumerConfigurable.h
+++ b/common/util/include/CircularIndexBufferSingleProducerSingleConsumerConfigurable.h
@@ -59,21 +59,21 @@ public:
      * Checks if the next element after end (wrap on overflow) is equal to begin.
      * @return True if the external buffer is full, or False otherwise.
      */
-    bool IsFull();
+    bool IsFull() const;
     
     /** Query whether external buffer is empty.
      *
      * Checks if begin is equal to end.
      * @return True if the external buffer is empty, or False otherwise.
      */
-    bool IsEmpty();
+    bool IsEmpty() const;
     
     /** Get write index.
      *
      * Indicates the start of a write operation.
      * @return CIRCULAR_INDEX_BUFFER_FULL if buffer is full, else the write index.
      */
-    unsigned int GetIndexForWrite();
+    unsigned int GetIndexForWrite() const;
     
     /** Advance write index.
      *
@@ -86,7 +86,7 @@ public:
      * Indicates the start of a read operation.
      * @return CIRCULAR_INDEX_BUFFER_EMPTY if buffer is empty, else the read index.
      */
-    unsigned int GetIndexForRead();
+    unsigned int GetIndexForRead() const;
     
     /** Advance read index.
      *
@@ -99,7 +99,7 @@ public:
      * Calculates how many elements exist between begin and end.
      * @return The number of elements in the external buffer that are currently being indexed.
      */
-    unsigned int NumInBuffer();
+    unsigned int NumInBuffer() const;
 
 private:
     /// Begin

--- a/common/util/include/CircularIndexBufferSingleProducerSingleConsumerConfigurable.h
+++ b/common/util/include/CircularIndexBufferSingleProducerSingleConsumerConfigurable.h
@@ -30,30 +30,84 @@
 #include <stdint.h>
 #include "hdtn_util_export.h"
 
+/// When equal to write index, the buffer is full.
 #define CIRCULAR_INDEX_BUFFER_FULL UINT32_MAX
+/// When equal to read index, the buffer is empty
 #define CIRCULAR_INDEX_BUFFER_EMPTY UINT32_MAX
 
 class HDTN_UTIL_EXPORT CircularIndexBufferSingleProducerSingleConsumerConfigurable {
 private:
     CircularIndexBufferSingleProducerSingleConsumerConfigurable();
 public:
+    /**
+     * Set the working size of the external buffer, then initialize begin and end to zero.
+     * @param size The working size of the associated external buffer.
+     */
     CircularIndexBufferSingleProducerSingleConsumerConfigurable(unsigned int size);
+    
+    /// Default destructor
     ~CircularIndexBufferSingleProducerSingleConsumerConfigurable();
 	
+    /** Reset bounds.
+     *
+     * Set begin and end back to zero.
+     */
     void Init();
+    
+    /** Query whether external buffer is full.
+     *
+     * Checks if the next element after end (wrap on overflow) is equal to begin.
+     * @return True if the external buffer is full, or False otherwise.
+     */
     bool IsFull();
+    
+    /** Query whether external buffer is empty.
+     *
+     * Checks if begin is equal to end.
+     * @return True if the external buffer is empty, or False otherwise.
+     */
     bool IsEmpty();
+    
+    /** Get write index.
+     *
+     * Indicates the start of a write operation.
+     * @return CIRCULAR_INDEX_BUFFER_FULL if buffer is full, else the write index.
+     */
     unsigned int GetIndexForWrite();
+    
+    /** Advance write index.
+     *
+     * Indicates the completion of the current active write operation, advances end one element forward (wrap on overflow).
+     */
     void CommitWrite();
+    
+    /** Get read index.
+     *
+     * Indicates the start of a read operation.
+     * @return CIRCULAR_INDEX_BUFFER_EMPTY if buffer is empty, else the read index.
+     */
     unsigned int GetIndexForRead();
+    
+    /** Advance read index.
+     *
+     * Indicates the completion of the current active read operation, advances begin one element forward (wrap on overflow).
+     */
     void CommitRead();
+    
+    /** Get the number of active elements in the external buffer.
+     *
+     * Calculates how many elements exist between begin and end.
+     * @return The number of elements in the external buffer that are currently being indexed.
+     */
     unsigned int NumInBuffer();
 
 private:
+    /// Begin
     volatile unsigned int m_cbStartIndex;
+    /// End
     volatile unsigned int m_cbEndIndex;
+    /// Working size of the external buffer
     const unsigned int M_CIRCULAR_INDEX_BUFFER_SIZE;
-	
 };
 
 

--- a/common/util/include/LtpClientServiceDataToSend.h
+++ b/common/util/include/LtpClientServiceDataToSend.h
@@ -36,41 +36,134 @@
 #include "hdtn_util_export.h"
 #include <boost/core/noncopyable.hpp>
 
+/**
+ * Data States (union-like state):
+ * 1. Byte buffer -> m_vector is active.
+ * 2. ZMQ message -> m_zmqMessage is active.
+ */
 class LtpClientServiceDataToSend : private boost::noncopyable {
 public:
+    /**
+     * Initialize an empty packet buffer
+     * @post Active data state: Byte buffer
+     */
     HDTN_UTIL_EXPORT LtpClientServiceDataToSend(); //a default constructor: X()
+    
+    /**
+     * Initialize the packet buffer to the given byte buffer.
+     * @param vec The byte buffer packet to set.
+     * @post Active data state: Byte buffer.
+     * @post The argument to vec is left in a moved-from state.
+     */
     HDTN_UTIL_EXPORT LtpClientServiceDataToSend(std::vector<uint8_t> && vec);
+    
+    /**
+     * If previously holding a ZMQ message, clean up its resources.
+     * Initialize the packet buffer to the given byte buffer.
+     * @param vec The byte buffer packet to set.
+     * @return *this.
+     * @post Active data state: Byte buffer.
+     * @post The argument to vec is left in a moved-from state.
+     */
     HDTN_UTIL_EXPORT LtpClientServiceDataToSend& operator=(std::vector<uint8_t> && vec); //a move assignment: operator=(X&&)
 #ifdef LTP_CLIENT_SERVICE_DATA_TO_SEND_SUPPORT_ZMQ
+    /**
+     * Initialize the packet buffer to the given ZMQ message.
+     * @param zmqMessage The ZMQ message to set.
+     * @post Active data state: ZMQ message.
+     */
     HDTN_UTIL_EXPORT LtpClientServiceDataToSend(zmq::message_t && zmqMessage);
+    
+    /**
+     * Initialize the packet buffer to the given ZMQ message.
+     * @param zmqMessage The ZMQ message to set.
+     * @return *this.
+     * @post Active data state: ZMQ message.
+     * @post The argument to zmqMessage is left in a moved-from state.
+     */
     HDTN_UTIL_EXPORT LtpClientServiceDataToSend& operator=(zmq::message_t && zmqMessage); //a move assignment: operator=(X&&)
 #endif
+    /// Default destructor
     HDTN_UTIL_EXPORT ~LtpClientServiceDataToSend(); //a destructor: ~X()
+    
+    /// Deleted copy constructor
     HDTN_UTIL_EXPORT LtpClientServiceDataToSend(const LtpClientServiceDataToSend& o) = delete; //disallow copying
+    
+    /// Default move constructor
     HDTN_UTIL_EXPORT LtpClientServiceDataToSend(LtpClientServiceDataToSend&& o) noexcept; //a move constructor: X(X&&)
+    
+    /// Deleted copy assignment operator
     HDTN_UTIL_EXPORT LtpClientServiceDataToSend& operator=(const LtpClientServiceDataToSend& o) = delete; //disallow copying
+    
+    /// Default move assignment operator
     HDTN_UTIL_EXPORT LtpClientServiceDataToSend& operator=(LtpClientServiceDataToSend&& o) noexcept; //a move assignment: operator=(X&&)
+    
+    /**
+     * @param vec The byte buffer to compare.
+     * @return Stored byte buffer == vec.
+     */
     HDTN_UTIL_EXPORT bool operator==(const std::vector<uint8_t> & vec) const; //operator ==
+    
+    /**
+     * @param vec The byte buffer to compare.
+     * @return Stored byte buffer != vec.
+     */
     HDTN_UTIL_EXPORT bool operator!=(const std::vector<uint8_t> & vec) const; //operator !=
+    
+    /** Get the begin pointer of the primary data buffer.
+     *
+     * Valid regardless of active data state.
+     * @return The begin pointer of the primary data buffer.
+     */
     HDTN_UTIL_EXPORT uint8_t * data() const;
+    
+    /** Get the size the primary data buffer.
+     *
+     * Valid regardless of active data state.
+     * @return The size of the primary data buffer.
+     */
     HDTN_UTIL_EXPORT std::size_t size() const;
+    
+    /** Clean up internal data buffers.
+     *
+     * Valid regardless of active data state.
+     * @param setSizeValueToZero Whether to reset the tracked size of the primary data buffer.
+     * @post The primary data buffer begin pointer is set to NULL.
+     */
     HDTN_UTIL_EXPORT void clear(bool setSizeValueToZero);
+    
+    /** Get the stored byte buffer.
+     *
+     * Reference to a default-constructed object when not the active data state.
+     * @return The stored byte buffer.
+     */
     HDTN_UTIL_EXPORT std::vector<uint8_t> & GetVecRef();
+    
+    /** Get the stored ZMQ message.
+     *
+     * Reference to a default-constructed object when not the active data state.
+     * @return The stored ZMQ message.
+     */
     HDTN_UTIL_EXPORT zmq::message_t & GetZmqRef();
 
 public:
+    /// Attached user data
     std::vector<uint8_t> m_userData;
 
 private:
+    /// Stored byte buffer
     std::vector<uint8_t> m_vector;
 #ifdef LTP_CLIENT_SERVICE_DATA_TO_SEND_SUPPORT_ZMQ
+    /// Stored ZMQ message
     zmq::message_t m_zmqMessage;
 #endif
+    /// Primary data buffer begin pointer
     uint8_t * m_ptrData;
+    /// Primary data buffer size
     std::size_t m_size;
 };
 
-struct UdpSendPacketInfo : private boost::noncopyable {
+struct UdpSendPacketInfo : private boost::noncopyable { //TODO: Docs, complete
     std::vector<boost::asio::const_buffer> constBufferVec;
     std::shared_ptr<std::vector<std::vector<uint8_t> > > underlyingDataToDeleteOnSentCallback;
     std::shared_ptr<LtpClientServiceDataToSend> underlyingCsDataToDeleteOnSentCallback;

--- a/common/util/include/SignalHandler.h
+++ b/common/util/include/SignalHandler.h
@@ -22,6 +22,7 @@
 #include <boost/asio.hpp>
 #include <boost/thread.hpp>
 #include <boost/function.hpp>
+#include <memory>
 #include "hdtn_util_export.h"
 
 class SignalHandler {
@@ -64,7 +65,7 @@ private:
     /// Signal event listener
     boost::asio::signal_set m_signals;
     /// Thread that invokes m_ioService.run() (if using dedicated I/O thread)
-    boost::thread *m_ioServiceThread;
+    std::unique_ptr<boost::thread> m_ioServiceThreadPtr;
     /// Callback to invoke after a signal is received
     boost::function<void() > m_handleSignalFunction;
 };

--- a/common/util/include/SignalHandler.h
+++ b/common/util/include/SignalHandler.h
@@ -28,31 +28,44 @@ class SignalHandler {
 private:
     SignalHandler();
 public:
+    /**
+     * Set the signal handler callback.
+     * Register keyboard interrupt signals to listen for.
+     * @param handleSignalFunction The signal handler callback.
+     */
     HDTN_UTIL_EXPORT SignalHandler(boost::function<void() > handleSignalFunction);
+    
+    /// Release all underlying I/O resources
     HDTN_UTIL_EXPORT ~SignalHandler();
-
-
+    
+    /** Start the signal event listener.
+     *
+     * @param useDedicatedThread Whether to spawn a separate thread for the I/O.
+     */
     HDTN_UTIL_EXPORT void Start(bool useDedicatedThread = true);
 
-    //use when useDedicatedThread is set to false
-    //return true if signal handler called
+    /** Poll signal event listener.
+     *
+     * Only call when NOT using a dedicated I/O thread.
+     * @return True if any signal events have occurred since last checked, or False otherwise.
+     */
     HDTN_UTIL_EXPORT bool PollOnce();
 
 private:
-
+    /** Handle signal event.
+     *
+     * Invokes the signal event handler callback.
+     */
     HDTN_UTIL_EXPORT void HandleSignal();
 
 private:
-    /// The io_service used to perform asynchronous operations.
+    /// I/O execution context
     boost::asio::io_service m_ioService;
-
-    /// The signal_set is used to register for process termination notifications.
+    /// Signal event listener
     boost::asio::signal_set m_signals;
-
+    /// Thread that invokes m_ioService.run() (if using dedicated I/O thread)
     boost::thread *m_ioServiceThread;
-
+    /// Callback to invoke after a signal is received
     boost::function<void() > m_handleSignalFunction;
-
-
 };
 #endif

--- a/common/util/include/UdpBatchSender.h
+++ b/common/util/include/UdpBatchSender.h
@@ -32,50 +32,150 @@
 
 class UdpBatchSender {
 public:
+    /**
+     * @typedef OnSentPacketsCallback_t Type of callback to be invoked after a packet batch send operation
+     */
     typedef boost::function<void(bool success, std::vector<std::vector<boost::asio::const_buffer> >& constBufferVecs,
         std::vector<std::shared_ptr<std::vector<std::vector<uint8_t> > > >& underlyingDataToDeleteOnSentCallbackVec,
         std::vector<std::shared_ptr<LtpClientServiceDataToSend> >& underlyingCsDataToDeleteOnSentCallbackVec)> OnSentPacketsCallback_t;
+    
+    /// Bind socket to io_service, does not open the socket
     HDTN_UTIL_EXPORT UdpBatchSender();
+    
+    /// Call UdpBatchSender::Stop() to release managed resources
     HDTN_UTIL_EXPORT ~UdpBatchSender();
+    
+    /** Perform graceful shutdown.
+     *
+     * If no previous successful call to UdpBatchSender::Init(), returns immediately.
+     * Else, tries to perform graceful shutdown on the socket, then releases all underlying I/O resources.
+     * @post The object is ready to be reused after the next successful call to UdpBatchSender::Init().
+     */
     HDTN_UTIL_EXPORT void Stop();
+    
+    /** Initialize the underlying I/O and connect to given host at given port.
+     *
+     * @param remoteHostname The remote host to connect to.
+     * @param remotePort The remote port to connect to.
+     * @return True if the connection could be established, or False if connection failed or the object has already been initialized.
+     */
     HDTN_UTIL_EXPORT bool Init(const std::string& remoteHostname, const uint16_t remotePort);
+    
+    /** Initialize the underlying I/O and connect to given UDP endpoint.
+     *
+     * @param udpDestinationEndpoint The remote UDP endpoint to connect to.
+     * @return True if the connection could be established, or False if connection failed or the object has already been initialized.
+     */
     HDTN_UTIL_EXPORT bool Init(const boost::asio::ip::udp::endpoint & udpDestinationEndpoint);
+    
+    /** Get the current UDP endpoint.
+     *
+     * @return The current UDP endpoint.
+     */
     HDTN_UTIL_EXPORT boost::asio::ip::udp::endpoint GetCurrentUdpEndpoint() const;
 
+    /** Initiate a packet batch send operation (thread-safe).
+     *
+     * Initiates an asynchronous request to UdpBatchSender::PerformSendPacketsOperation().
+     * @param constBufferVecs The packets to send.
+     * @param underlyingDataToDeleteOnSentCallbackVec (internal) Vector of LtpClientServiceDataToSend::underlyingDataToDeleteOnSentCallback.
+     * @param underlyingCsDataToDeleteOnSentCallbackVec (internal) Vector of LtpClientServiceDataToSend::underlyingCsDataToDeleteOnSentCallback.
+     */
     HDTN_UTIL_EXPORT void QueueSendPacketsOperation_ThreadSafe(std::vector<std::vector<boost::asio::const_buffer> >& constBufferVecs,
         std::vector<std::shared_ptr<std::vector<std::vector<uint8_t> > > >& underlyingDataToDeleteOnSentCallbackVec,
         std::vector<std::shared_ptr<LtpClientServiceDataToSend> >& underlyingCsDataToDeleteOnSentCallbackVec);
+    
+    /** Set the onSentPackets callback.
+     *
+     * @param callback The callback to set.
+     */
     HDTN_UTIL_EXPORT void SetOnSentPacketsCallback(const OnSentPacketsCallback_t& callback);
+    
+    /** Initiate a request to connect (thread-safe).
+     *
+     * Initiates an asynchronous request to UdpBatchSender::SetEndpointAndReconnect().
+     * @param remoteEndpoint The remote UDP endpoint to connect to.
+     */
     HDTN_UTIL_EXPORT void SetEndpointAndReconnect_ThreadSafe(const boost::asio::ip::udp::endpoint& remoteEndpoint);
+    
+    /** Initiate a request to connect (thread-safe).
+     *
+     * Initiates an asynchronous request to UdpBatchSender::SetEndpointAndReconnect().
+     * @param remoteHostname The remote host to connect to.
+     * @param remotePort The remote port to connect to.
+     */
     HDTN_UTIL_EXPORT void SetEndpointAndReconnect_ThreadSafe(const std::string& remoteHostname, const uint16_t remotePort);
 
 private:
+    /** Connect to given UDP endpoint.
+     *
+     * @param remoteEndpoint The remote UDP endpoint to connect to.
+     * @return True if the connection could be established, or False otherwise.
+     */
     HDTN_UTIL_NO_EXPORT bool SetEndpointAndReconnect(const boost::asio::ip::udp::endpoint& remoteEndpoint);
+    
+    /** Connect to given host at given port.
+     *
+     * @param remoteHostname The remote host to connect to.
+     * @param remotePort The remote port to connect to.
+     * @return True if the connection could be established, or False otherwise.
+     */
     HDTN_UTIL_NO_EXPORT bool SetEndpointAndReconnect(const std::string& remoteHostname, const uint16_t remotePort);
+    
+    /** Perform a packet batch send operation. //TODO: Docs, complete
+     *
+     * Performs a single synchronous batch send operation.
+     * After it finishes (successfully or otherwise), the callback stored in m_onSentPacketsCallback (if any) is invoked.
+     * @param constBufferVecs
+     * @param underlyingDataToDeleteOnSentCallbackVec
+     * @param underlyingCsDataToDeleteOnSentCallbackVec
+     * @post The arguments to constBufferVecs, underlyingDataToDeleteOnSentCallbackVec and underlyingCsDataToDeleteOnSentCallbackVec are left in a moved-from state.
+     */
     HDTN_UTIL_NO_EXPORT void PerformSendPacketsOperation(
         std::vector<std::vector<boost::asio::const_buffer> >& constBufferVecs,
         std::vector<std::shared_ptr<std::vector<std::vector<uint8_t> > > >& underlyingDataToDeleteOnSentCallbackVec,
         std::vector<std::shared_ptr<LtpClientServiceDataToSend> >& underlyingCsDataToDeleteOnSentCallbackVec);
+    
+    /** Initiate request for socket shutdown.
+     *
+     * Initiates an asynchronous request to UdpBatchSender::DoHandleSocketShutdown().
+     */
     HDTN_UTIL_NO_EXPORT void DoUdpShutdown();
+    
+    /** Perform socket shutdown.
+     *
+     * If a connection is not open, returns immediately.
+     * @post The underlying socket mechanism is ready to be reused after a successful call to UdpBatchSender::SetEndpointAndReconnect().
+     */
     HDTN_UTIL_NO_EXPORT void DoHandleSocketShutdown();
 private:
 
+    /// I/O execution context
     boost::asio::io_service m_ioService;
+    /// Explicit work controller for m_ioService, allows for graceful shutdown of running tasks
     std::unique_ptr<boost::asio::io_service::work> m_workPtr;
+    /// UDP socket to connect to destination endpoint
     boost::asio::ip::udp::socket m_udpSocketConnectedSenderOnly;
+    /// UDP destination endpoint
     boost::asio::ip::udp::endpoint m_udpDestinationEndpoint;
+    /// Thread that invokes m_ioService.run()
     std::unique_ptr<boost::thread> m_ioServiceThreadPtr;
 #ifdef _WIN32
 //# define UDP_BATCH_SENDER_USE_OVERLAPPED 1
+    /// WINAPI TransmitPackets function pointer
     LPFN_TRANSMITPACKETS m_transmitPacketsFunctionPointer;
 # ifdef UDP_BATCH_SENDER_USE_OVERLAPPED
+    /// Overlapped I/O object, always configured to auto-reset
     WSAOVERLAPPED m_sendOverlappedAutoReset;
 # endif
+    /// Vector of packets to send
     std::vector<TRANSMIT_PACKETS_ELEMENT> m_transmitPacketsElementVec;
 #else //not #ifdef _WIN32
+    /// Vector of packets to send
     std::vector<struct mmsghdr> m_transmitPacketsElementVec;
 #endif
     
+    /// Callback to invoke after a packet batch send operation
     OnSentPacketsCallback_t m_onSentPacketsCallback;
 };
 

--- a/common/util/src/CircularIndexBufferSingleProducerSingleConsumerConfigurable.cpp
+++ b/common/util/src/CircularIndexBufferSingleProducerSingleConsumerConfigurable.cpp
@@ -32,18 +32,18 @@ void CircularIndexBufferSingleProducerSingleConsumerConfigurable::Init() {
 }
 
 
-bool CircularIndexBufferSingleProducerSingleConsumerConfigurable::IsFull() {
+bool CircularIndexBufferSingleProducerSingleConsumerConfigurable::IsFull() const {
     //return ((m_end + 1) % m_bufferSize) == m_start;
     unsigned int endPlus1 = m_cbEndIndex + 1;
         if (endPlus1 >= M_CIRCULAR_INDEX_BUFFER_SIZE) endPlus1 = 0;
     return (m_cbStartIndex == endPlus1);
 }
 
-bool CircularIndexBufferSingleProducerSingleConsumerConfigurable::IsEmpty() {
+bool CircularIndexBufferSingleProducerSingleConsumerConfigurable::IsEmpty() const {
 	return (m_cbEndIndex == m_cbStartIndex);
 }
 
-unsigned int CircularIndexBufferSingleProducerSingleConsumerConfigurable::GetIndexForWrite() {
+unsigned int CircularIndexBufferSingleProducerSingleConsumerConfigurable::GetIndexForWrite() const {
 	if (IsFull())
 		return CIRCULAR_INDEX_BUFFER_FULL;
 	return m_cbEndIndex;
@@ -58,7 +58,7 @@ void CircularIndexBufferSingleProducerSingleConsumerConfigurable::CommitWrite() 
 	m_cbEndIndex = endPlus1;
 }
 
-unsigned int CircularIndexBufferSingleProducerSingleConsumerConfigurable::GetIndexForRead() {
+unsigned int CircularIndexBufferSingleProducerSingleConsumerConfigurable::GetIndexForRead() const {
 	if (IsEmpty())
 		return CIRCULAR_INDEX_BUFFER_EMPTY;
 	return m_cbStartIndex;
@@ -74,7 +74,7 @@ void CircularIndexBufferSingleProducerSingleConsumerConfigurable::CommitRead() {
 	
 }
 
-unsigned int CircularIndexBufferSingleProducerSingleConsumerConfigurable::NumInBuffer() {
+unsigned int CircularIndexBufferSingleProducerSingleConsumerConfigurable::NumInBuffer() const {
     unsigned int endIndex = m_cbEndIndex;
     const unsigned int startIndex = m_cbStartIndex;
     if (endIndex < startIndex) {

--- a/common/util/src/UdpBatchSender.cpp
+++ b/common/util/src/UdpBatchSender.cpp
@@ -114,8 +114,13 @@ bool UdpBatchSender::Init(const boost::asio::ip::udp::endpoint& udpDestinationEn
     }
 # endif
     m_transmitPacketsElementVec.reserve(100);
+#else
+    m_transmitPacketsElementVec.reserve(50);
 #endif
-
+    // github comment https://github.com/nasa/HDTN/pull/36#issuecomment-1373562636: The m_transmitPacketsElementVec vector gets more pushes for windows
+    // (one push per piece of a udp packet) than it does on linux (one push per udp packet, recommended to reserve 50 for linux and 100 for windows.
+    
+    
     m_workPtr = boost::make_unique<boost::asio::io_service::work>(m_ioService);
     m_ioServiceThreadPtr = boost::make_unique<boost::thread>(boost::bind(&boost::asio::io_service::run, &m_ioService));
 
@@ -194,7 +199,7 @@ void UdpBatchSender::PerformSendPacketsOperation(
     std::vector<std::shared_ptr<LtpClientServiceDataToSend> >& underlyingCsDataToDeleteOnSentCallbackVec)
 {
 
-    m_transmitPacketsElementVec.resize(0); //reserved 100 elements in Init()
+    m_transmitPacketsElementVec.resize(0); //space has been reserved in UdpBatchSender::Init()
     
 
     for (std::size_t i = 0; i < constBufferVecs.size(); ++i) {

--- a/module/udp_delay_sim/include/UdpDelaySim.h
+++ b/module/udp_delay_sim/include/UdpDelaySim.h
@@ -37,7 +37,24 @@ class UdpDelaySim {
 private:
     UdpDelaySim();
 public:
+    /**
+     * @typedef Type of predicate to be invoked during packet drop simulation.
+     * @return True if the packet should be dropped, or False otherwise.
+     */
     typedef boost::function<bool(const std::vector<uint8_t> & udpPacketReceived, std::size_t bytesTransferred)> UdpDropSimulatorFunction_t;
+    
+    /**
+     * Bind I/O components to m_ioService.
+     * Preallocate transmission buffers.
+     * If autoStart is set to True, call UdpDelaySim::StartIfNotAlreadyRunning() to start the server.
+     * @param myBoundUdpPort The port to bind the UDP server on.
+     * @param remoteHostnameToForwardPacketsTo The forwarding destination host.
+     * @param remotePortToForwardPacketsTo The forwarding destination port.
+     * @param numCircularBufferVectors The size of the transmission buffers.
+     * @param maxUdpPacketSizeBytes The maximum size of a UDP packet in bytes.
+     * @param sendDelay The delay duration for packet forwarding.
+     * @param autoStart Whether the server should start automatically on construction.
+     */
     UDP_DELAY_SIM_LIB_EXPORT UdpDelaySim(uint16_t myBoundUdpPort,
         const std::string & remoteHostnameToForwardPacketsTo,
         const std::string & remotePortToForwardPacketsTo,
@@ -45,68 +62,201 @@ public:
         const unsigned int maxUdpPacketSizeBytes,
         const boost::posix_time::time_duration & sendDelay,
         const bool autoStart);
+    
+    /// Call UdpDelaySim::Stop() to release managed resources
     UDP_DELAY_SIM_LIB_EXPORT ~UdpDelaySim();
+    
+    /** Perform server shutdown.
+     *
+     * Calls UdpDelaySim::DoUdpShutdown() to release UDP resources, then releases all underlying I/O resources.
+     * @post The object is ready to be reused after the next successful call to UdpDelaySim::StartIfNotAlreadyRunning().
+     */
     UDP_DELAY_SIM_LIB_EXPORT void Stop();
+    
+    /** Start the UDP server and initiate resolving of the forwarding destination endpoint.
+     *
+     * If the server is already running, returns immediately.
+     * Starts the stat tracking interval loop, then starts the server.
+     * Initiates an asynchronous resolve operation to resolve the forwarding destination endpoint with UdpDelaySim::OnResolve() as a completion handler.
+     * @return True if the server could be started successfully or is already running, or False otherwise.
+     * @post If the server was not already running, the server will NOT be listening for packets yet.
+     */
     UDP_DELAY_SIM_LIB_EXPORT bool StartIfNotAlreadyRunning();
+    
+    /** Stop timers and close listening socket.
+     *
+     * Stops transmission and stat tracking timers, then closes the listening socket.
+     * @post The UDP resources are ready to be reused, but the server will remain in the running state until the next call to UdpDelaySim::Stop().
+     */
     UDP_DELAY_SIM_LIB_EXPORT void DoUdpShutdown();
+    
+    /** Initiate a request to set the udpDropSimulator function (thread-safe).
+     *
+     * Initiates an asynchronous request to UdpDelaySim::SetUdpDropSimulatorFunction().
+     * The calling thread blocks until the request is resolved.
+     * @param udpDropSimulatorFunction The function to set.
+     */
     UDP_DELAY_SIM_LIB_EXPORT void SetUdpDropSimulatorFunction_ThreadSafe(const UdpDropSimulatorFunction_t & udpDropSimulatorFunction);
+    
+    /** Queue packet for delayed transmission.
+     *
+     * Timestamps the packet for transmission clearance using the configured transmission delay duration, then places the packet in the transmission queue.
+     * udpPacketToSwapIn holds the entire receive buffer with a size of M_MAX_UDP_PACKET_SIZE_BYTES, only the first bytesTransferred bytes belong
+     * in the current packet and are therefore safe to read, any bytes that follow may contain partial data from previously processed packets
+     * and should be treated as garbage values.
+     * @param udpPacketToSwapIn The packet to transmit.
+     * @param bytesTransferred The size of the packet.
+     * @post The argument to udpPacketToSwapIn is swapped with a potentially dirty buffer of an already-processed packet and is ready to
+     * be reused as the receive buffer for the next read operation (see above how to handle dirty buffers).
+     */
     UDP_DELAY_SIM_LIB_EXPORT void QueuePacketForDelayedSend_NotThreadSafe(std::vector<uint8_t> & udpPacketToSwapIn, std::size_t bytesTransferred);
 private:
+    /** Set the udpDropSimulator function.
+     *
+     * @param udpDropSimulatorFunction The function to set.
+     */
     UDP_DELAY_SIM_LIB_NO_EXPORT void SetUdpDropSimulatorFunction(const UdpDropSimulatorFunction_t & udpDropSimulatorFunction);
+    
+    /** Cache resolved forwarding destination UDP endpoint and start the receive loop for the packet origin.
+     *
+     * If an error occurred during the resolve operation, returns immediately letting m_ioService run out of work and leaving the server in an idle state, to retry
+     * a server restart would be necessary, achieved by a call to UdpDelaySim::Stop() followed by a successful call to UdpDelaySim::StartIfNotAlreadyRunning().
+     * Else, calls UdpDelaySim::StartUdpReceive() to start the receive loop.
+     * @param ec The error code.
+     * @param results The resolved UDP endpoint.
+     */
     UDP_DELAY_SIM_LIB_NO_EXPORT void OnResolve(const boost::system::error_code & ec, boost::asio::ip::udp::resolver::results_type results);
+    
+    /** Start the receive loop for the packet origin.
+     *
+     * Initiates an asynchronous receive operation with UdpDelaySim::HandleUdpReceive() as a completion handler.
+     */
     UDP_DELAY_SIM_LIB_NO_EXPORT void StartUdpReceive();
+    
+    /** Handle a UDP receive operation.
+     *
+     * If a fatal error occurred during the receive operation, calls UdpDelaySim::DoUdpShutdown().
+     * If a packet is not to be dropped by the drop simulation utility (if/when active), queues packet for delayed transmission.
+     * On successful processing, initiates an asynchronous receive operation with itself as a completion handler to achieve a receive loop.
+     * @param error The error code.
+     * @param bytesTransferred The number of bytes received.
+     */
     UDP_DELAY_SIM_LIB_NO_EXPORT void HandleUdpReceive(const boost::system::error_code & error, std::size_t bytesTransferred);
+    
+    /** Handle a UDP send operation.
+     *
+     * If an error occurred during the send operation, calls UdpDelaySim::DoUdpShutdown().
+     * Else, calls UdpDelaySim::TryRestartSendDelayTimer() to queue the next packet for transmission.
+     * @param error The error code.
+     * @param bytes_transferred The number of bytes sent.
+     */
     UDP_DELAY_SIM_LIB_NO_EXPORT void HandleUdpSend(const boost::system::error_code& error, std::size_t bytes_transferred);
 
+    /** Start the delay timer for the next packet in the transmission queue.
+     *
+     * If the timer is already running or there are no packets available in the transmission queue, returns immediately.
+     * Else, starts the transmission delay timer asynchronously for the next packet in the transmission queue with OnSendDelay_TimerExpired() as a completion handler.
+     * The timer runs for the remaining delay duration (if any left) from the time the packet was enqueued for transmission.
+     */
     UDP_DELAY_SIM_LIB_NO_EXPORT void TryRestartSendDelayTimer();
+    
+    /** Handle transmission delay timer expiry.
+     *
+     * If the expiry occurred due to the timer being manually cancelled, returns immediately.
+     * Else, initiates an asynchronous send operation to forward the packet associated with consumeIndex to the forwarding destination,
+     * with UdpDelaySim::HandleUdpSend() as a completion handler.
+     * @param e The error code.
+     * @param consumeIndex The index of the associated packet.
+     */
     UDP_DELAY_SIM_LIB_NO_EXPORT void OnSendDelay_TimerExpired(const boost::system::error_code& e, const unsigned int consumeIndex);
-
+    
+    /** Handle stat tracking timer expiry.
+     *
+     * If the expiry occurred due to the timer being manually cancelled, returns immediately.
+     * Else, updates tracked stats and starts the stat tracking timer asynchronously with itself as a completion handler to achieve a stat tracking loop.
+     */
     UDP_DELAY_SIM_LIB_NO_EXPORT void TransferRate_TimerExpired(const boost::system::error_code& e);
 public:
     
 
 private:
 
+    /// I/O execution context
     boost::asio::io_service m_ioService;
+    /// UDP endpoint resolver
     boost::asio::ip::udp::resolver m_resolver;
+    /// Forwarding delay timer, on expiry forward kept packet
     boost::asio::deadline_timer m_udpPacketSendDelayTimer;
+    /// Stat tracking timer, on expiry update stats and restart interval
     boost::asio::deadline_timer m_timerTransferRateStats;
+    /// UDP server socket
     boost::asio::ip::udp::socket m_udpSocket;
 
+    /// Time point, used by the stat tracking mechanism to calculate delta time
     boost::posix_time::ptime m_lastPtime;
     
+    /// Our UDP server port, if the port number 0 the server socket is bound to a random ephemeral port
     const uint16_t M_MY_BOUND_UDP_PORT;
+    /// Forwarding destination host
     const std::string M_REMOTE_HOSTNAME_TO_FORWARD_PACKETS_TO;
+    /// Forwarding destination port
     const std::string M_REMOTE_PORT_TO_FORWARD_PACKETS_TO;
+    /// Number of transmission buffers
     const unsigned int M_NUM_CIRCULAR_BUFFER_VECTORS;
+    /// Maximum size of a UDP packet in bytes
     const unsigned int M_MAX_UDP_PACKET_SIZE_BYTES;
+    /// Forwarding delay duration
     const boost::posix_time::time_duration M_SEND_DELAY;
+    /// Packet receive buffer
     std::vector<uint8_t> m_udpReceiveBuffer;
+    /// Packet origin UDP endpoint
     boost::asio::ip::udp::endpoint m_remoteEndpointReceived;
+    /// Forwarding destination UDP endpoint
     boost::asio::ip::udp::endpoint m_udpDestinationEndpoint;
+    /// Circular index buffer, used to index the circular vector holding packet metadata necessary for transmission
     CircularIndexBufferSingleProducerSingleConsumerConfigurable m_circularIndexBuffer;
+    /// Circular vector of receive buffers, each receive buffer holds the entire m_udpReceiveBuffer, NOT just the bytes of the received packet
     std::vector<std::vector<uint8_t> > m_udpReceiveBuffersCbVec;
+    /// Circular vector of packet size per receive buffer, the actual size of the received packet
     std::vector<uint64_t> m_udpReceiveBytesTransferredCbVec;
+    /// Circular vector of expiry time point per packet, the absolute time when the packet receives clearance for transmission
     std::vector<boost::posix_time::ptime> m_expiriesCbVec;
+    /// Thread that invokes m_ioService.run()
     std::unique_ptr<boost::thread> m_ioServiceThreadPtr;
+    /// Logger flag, set to False to log a notice on the SINGLE next increment of m_countCircularBufferOverruns
     bool m_printedCbTooSmallNotice;
+    /// Whether m_udpPacketSendDelayTimer is currently active
     bool m_sendDelayTimerIsRunning;
+    /// Packet drop simulation state update flag, whether a state update operation is currently active
     volatile bool m_setUdpDropSimulatorFunctionInProgress;
+    /// Packet drop simulation state update condition variable
     boost::condition_variable m_cvSetUdpDropSimulatorFunction;
+    /// Packet drop simulation state update mutex
     boost::mutex m_mutexSetUdpDropSimulatorFunction;
+    /// Packet drop simulation function
     UdpDropSimulatorFunction_t m_udpDropSimulatorFunction;
 
     //stats
+    /// The value of m_countTotalUdpPacketsReceived frozen for next stat tracking window
     uint64_t m_lastTotalUdpPacketsReceived;
+    /// The value of m_countTotalUdpBytesReceived frozen for next stat tracking window
     uint64_t m_lastTotalUdpBytesReceived;
+    /// The value of m_countTotalUdpPacketsSent frozen for next stat tracking window
     uint64_t m_lastTotalUdpPacketsSent;
+    /// The value of m_countTotalUdpBytesSent frozen for next stat tracking window
     uint64_t m_lastTotalUdpBytesSent;
 public:
+    /// Total number of requests attempted to queue a packet for transmission while transmission buffers were full
     uint64_t m_countCircularBufferOverruns;
+    /// Maximum recorded number of packets queued for transmission at a single point in time
     uint64_t m_countMaxCircularBufferSize;
+    /// Total number of UDP packets received from origin
     uint64_t m_countTotalUdpPacketsReceived;
+    /// Total number of UDP bytes received from origin
     uint64_t m_countTotalUdpBytesReceived;
+    /// Total number of UDP packets forwarded to destination
     uint64_t m_countTotalUdpPacketsSent;
+    /// Total number of UDP bytes forwarded to destination
     uint64_t m_countTotalUdpBytesSent;
 };
 

--- a/module/udp_delay_sim/include/UdpDelaySimRunner.h
+++ b/module/udp_delay_sim/include/UdpDelaySimRunner.h
@@ -25,13 +25,29 @@
 
 class UdpDelaySimRunner {
 public:
+    /// Default constructor
     UDP_DELAY_SIM_LIB_EXPORT UdpDelaySimRunner();
+    /// Default destructor
     UDP_DELAY_SIM_LIB_EXPORT ~UdpDelaySimRunner();
+    
+    /** Run the delay simulation.
+     *
+     * @param argc The number of command-line arguments.
+     * @param argv The array of command-line arguments.
+     * @param running The simulation running flag.
+     * @param useSignalHandler Whether to activate the signal handler.
+     * @return True if the simulation exited cleanly, or False otherwise.
+     */
     UDP_DELAY_SIM_LIB_EXPORT bool Run(int argc, const char* const argv[], volatile bool & running, bool useSignalHandler);
     
 private:
+    /** Set the exit flag from the signal handler.
+     *
+     * Forwards intent to exit by setting m_runningFromSigHandler to False due to exit keypress being caught by the signal handler.
+     */
     UDP_DELAY_SIM_LIB_NO_EXPORT void MonitorExitKeypressThreadFunction();
 
+    /// Signal handler flag, whether the simulation should keep running
     volatile bool m_runningFromSigHandler;
 };
 

--- a/module/udp_delay_sim/src/UdpDelaySim.cpp
+++ b/module/udp_delay_sim/src/UdpDelaySim.cpp
@@ -161,7 +161,7 @@ void UdpDelaySim::HandleUdpReceive(const boost::system::error_code & error, std:
     }
 }
 
-//udpPacketToSwapIn.size() is not the size of the udp packet but rather bytesTransferred is
+//udpPacketToSwapIn.size() is not the size of the udp packet but rather bytesTransferred is (see docs)
 void UdpDelaySim::QueuePacketForDelayedSend_NotThreadSafe(std::vector<uint8_t>& udpPacketToSwapIn, std::size_t bytesTransferred) {
     const unsigned int writeIndex = m_circularIndexBuffer.GetIndexForWrite(); //store the volatile
     if (writeIndex == CIRCULAR_INDEX_BUFFER_FULL) {
@@ -200,8 +200,6 @@ void UdpDelaySim::DoUdpShutdown() {
 
 }
 
-
-//restarts the send delay timer if it is not running and there are packets available
 void UdpDelaySim::TryRestartSendDelayTimer() {
     if (!m_sendDelayTimerIsRunning) {
         const unsigned int consumeIndex = m_circularIndexBuffer.GetIndexForRead(); //store the volatile

--- a/module/udp_delay_sim/src/UdpDelaySimRunner.cpp
+++ b/module/udp_delay_sim/src/UdpDelaySimRunner.cpp
@@ -27,7 +27,7 @@ static constexpr hdtn::Logger::SubProcess subprocess = hdtn::Logger::SubProcess:
 
 void UdpDelaySimRunner::MonitorExitKeypressThreadFunction() {
     LOG_INFO(subprocess) << "Keyboard Interrupt.. exiting";
-    m_runningFromSigHandler = false; //do this first
+    m_runningFromSigHandler = false;
 }
 
 


### PR DESCRIPTION
@briantomko Could you describe the lifetime of a send operation and its associated context for the LTP layer once more? Wasn't confident in documenting `UdpSendPacketInfo` and the usage of its fields just yet, the places where docs are missing are marked with `//TODO: Docs, complete`.

Left out the LtpOverUdp induct/outduct classes from this one since most of the functionality they add just maps to function calls of higher-up layers, might as well visit them when documenting the base induct class.