### PR TITLE
Docs for core LTP components

### DIFF
--- a/common/ltp/include/LtpEngine.h
+++ b/common/ltp/include/LtpEngine.h
@@ -42,217 +42,1014 @@ class CLASS_VISIBILITY_LTP_LIB LtpEngine : private boost::noncopyable {
 private:
     LtpEngine() = delete;
 public:
+    /// Transmission request context data
     struct transmission_request_t {
+        /// Remote client service ID
         uint64_t destinationClientServiceId;
+        /// Remove LTP engine ID
         uint64_t destinationLtpEngineId;
+        /// Client service data to send
         LtpClientServiceDataToSend clientServiceDataToSend;
+        /// Red part data length in bytes
         uint64_t lengthOfRedPart;
+        /// Session attached client service data
         std::shared_ptr<LtpTransmissionRequestUserData> userDataPtr;
     };
+    
+    /// Session cancellation segment context data
     struct cancel_segment_timer_info_t {
+        /// Default constructor
         cancel_segment_timer_info_t() = default;
-        cancel_segment_timer_info_t(const uint8_t * data); //for queue emplace of user data
+        /**
+         * Initialize (this) by memcpy.
+         * Used for queue emplace of user data.
+         * @param data The object data to memcpy.
+         */
+        cancel_segment_timer_info_t(const uint8_t * data);
 
+        /// Session ID
         Ltp::session_id_t sessionId;
+        /// Reason code
         CANCEL_SEGMENT_REASON_CODES reasonCode;
+        /// Whether the cancellation segment was issued by the sender (if False, issued by receiver)
         bool isFromSender;
+        /// Number of retries
         uint8_t retryCount;
     };
     
+    /**
+     * Set RTT to (ltpRxOrTxCfg.oneWayLightTime * 2) + (ltpRxOrTxCfg.oneWayMarginTime * 2).
+     * Set housekeeping timer interval to 1000ms.
+     * initialize sender and receiver common data.
+     * Bind necessary callbacks.
+     * Call LtpEngine::SetMtuReportSegment().
+     * Call LtpEngine::UpdateRate().
+     * Call LtpEngine::Reset().
+     * Start the housekeeping timer asynchronously with LtpEngine::OnHousekeeping_TimerExpired() as a completion handler.
+     * If using the disk for intermediate storage AND we are not unit testing (if using a dedicated thread), initialize the disk memory manager.
+     * if using a dedicated thread, initialize the dedicated I/O thread.
+     */
     LTP_LIB_EXPORT LtpEngine(const LtpEngineConfig& ltpRxOrTxCfg, const uint8_t engineIndexForEncodingIntoRandomSessionNumber, bool startIoServiceThread);
 
+    /**
+     * If the dedicated I/O thread is active, clear the housekeeping timer, initiate an asynchronous reset to LtpEngine::Reset(), reset the
+     * explicit work object, then join and cleanup the dedicated I/O thread.
+     */
     LTP_LIB_EXPORT virtual ~LtpEngine();
 
+    /** Perform reset.
+     *
+     * Clear all active transmission and reception sessions and reserve space for (M_MAX_SIMULTANEOUS_SESSIONS << 1) sessions for both.
+     * Reset the Rx state machine.
+     * Reset all timer managers.
+     * Clear all segment queues.
+     * Start all stat counters back from 0.
+     */
     LTP_LIB_EXPORT virtual void Reset();
+    
+    /** Set checkpoint every Nth data packet across all senders.
+     *
+     * (see docs for LtpEngineConfig::checkpointEveryNthDataPacketSender).
+     * @param checkpointEveryNthDataPacketSender The value to set.
+     */
     LTP_LIB_EXPORT void SetCheckpointEveryNthDataPacketForSenders(uint64_t checkpointEveryNthDataPacketSender);
+    
+    /** Get the engine index.
+     *
+     * @return The engine index.
+     */
     LTP_LIB_EXPORT uint8_t GetEngineIndex();
 
+    /** Issue a transmission request.
+     *
+     * Calls LtpEngine::TransmissionRequest(trcd->destinationClientServiceId, trcd->destinationLtpEngineId, trcd->clientServiceDataToSend,
+     *                                      trcd->userDataPtr, trcd->lengthOfRedPart).
+     * @param transmissionRequest The transmission request context data.
+     * @post The arguments to (trcd->clientServiceDataToSend) and (trcd->userDataPtr) are left in a moved-from state.
+     */
     LTP_LIB_EXPORT void TransmissionRequest(std::shared_ptr<transmission_request_t> & transmissionRequest);
+    
+    /** Initiate a request to issue a transmission request (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpEngine::TransmissionRequest(transmissionRequest).
+     * @param transmissionRequest The transmission request context data.
+     * @post The argument to transmissionRequest is left in a moved-from state.
+     */
     LTP_LIB_EXPORT void TransmissionRequest_ThreadSafe(std::shared_ptr<transmission_request_t> && transmissionRequest);
+    
+    /** Issue a transmission request.
+     *
+     * If using the disk for intermediate storage, calls MemoryInFiles::AllocateNewWriteMemoryBlock() to allocate a new memory block, if the
+     * new block could be created successfully, calls MemoryInFiles::WriteMemoryAsync() with LtpEngine::OnTransmissionRequestDataWrittenToDisk()
+     * as a completion handler, attempting to initiate a deferred disk write, writing the client service data to send before the transmission request
+     * is initiated.
+     *
+     * Else, if NOT writing to disk, calls LtpEngine::DoTransmissionRequest() directly.
+     * @param destinationClientServiceId The remote client service ID.
+     * @param destinationLtpEngineId The remote LTP engine ID.
+     * @param clientServiceDataToSend The client service data to send.
+     * @param userDataPtrToTake The attached user data.
+     * @param lengthOfRedPart The red part data length in bytes.
+     * @post The arguments to clientServiceDataToSend and userDataPtrToTake are left in a moved-from state.
+     */
     LTP_LIB_EXPORT void TransmissionRequest(uint64_t destinationClientServiceId, uint64_t destinationLtpEngineId,
         LtpClientServiceDataToSend && clientServiceDataToSend, std::shared_ptr<LtpTransmissionRequestUserData> && userDataPtrToTake, uint64_t lengthOfRedPart);
+    
+    /** Issue a cancellation request.
+     *
+     * Copies the client service data to send.
+     * Calls LtpEngine::TransmissionRequest(destinationClientServiceId, destinationLtpEngineId,
+     *                                      std::vector<uint8_t>(clientServiceDataToCopyAndSend, clientServiceDataToCopyAndSend + length),
+     *                                      userDataPtrToTake, lengthOfRedPart).
+     * @param destinationClientServiceId The remote client service ID.
+     * @param destinationLtpEngineId The remote LTP engine ID.
+     * @param clientServiceDataToCopyAndSend The client service data to send.
+     * @param length The client service data length in bytes.
+     * @param userDataPtrToTake The attached user data.
+     * @param lengthOfRedPart The red part data length in bytes.
+     * @post The argument to userDataPtrToTake is left in a moved-from state.
+     */
     LTP_LIB_EXPORT void TransmissionRequest(uint64_t destinationClientServiceId, uint64_t destinationLtpEngineId,
         const uint8_t * clientServiceDataToCopyAndSend, uint64_t length, std::shared_ptr<LtpTransmissionRequestUserData> && userDataPtrToTake, uint64_t lengthOfRedPart);
+    
+    /** Issue a transmission request.
+     *
+     * Copies the client service data to send.
+     * Calls LtpEngine::TransmissionRequest(destinationClientServiceId, destinationLtpEngineId,
+     *                                      std::vector<uint8_t>(clientServiceDataToCopyAndSend, clientServiceDataToCopyAndSend + length),
+     *                                      nullptr, lengthOfRedPart).
+     * @param destinationClientServiceId The remote client service ID.
+     * @param destinationLtpEngineId The remote LTP engine ID.
+     * @param clientServiceDataToCopyAndSend The client service data to send.
+     * @param length The client service data length in bytes.
+     * @param lengthOfRedPart The red part data length in bytes.
+     */
     LTP_LIB_EXPORT void TransmissionRequest(uint64_t destinationClientServiceId, uint64_t destinationLtpEngineId,
         const uint8_t * clientServiceDataToCopyAndSend, uint64_t length, uint64_t lengthOfRedPart);
 private:
+    /** Issue a transmission request.
+     *
+     * Marks that transmission request should serve as a ping.
+     * Attempts to append a new transmission session to the active transmission sessions queue, if the insertion operation fails returns immediately.
+     * Else, appends the newly created sender to the senders needing first-pass data sent queue, then if the session start callback
+     * is set, calls LtpEngine::m_sessionStartCallback() to invoke the session start callback.
+     * Finally calls LtpEngine::TrySaturateSendPacketPipeline() to resume processing.
+     * @param destinationClientServiceId The remote client service ID.
+     * @param destinationLtpEngineId The remote LTP engine ID.
+     * @param clientServiceDataToSend The client service data to send.
+     * @param userDataPtrToTake The attached user data.
+     * @param lengthOfRedPart The red part data length in bytes.
+     * @param memoryBlockId The memory block ID.
+     */
     LTP_LIB_NO_EXPORT void DoTransmissionRequest(uint64_t destinationClientServiceId, uint64_t destinationLtpEngineId,
         LtpClientServiceDataToSend&& clientServiceDataToSend, std::shared_ptr<LtpTransmissionRequestUserData>&& userDataPtrToTake, uint64_t lengthOfRedPart, uint64_t memoryBlockId);
+    
+    /** Handle transmission request disk write completion.
+     *
+     * Clears the client service data to send from memory to free up space since the data have been written to disk.
+     * Calls DoTransmissionRequest(destinationClientServiceId, destinationLtpEngineId,
+     *                             *clientServiceDataToSendPtrToTake, userDataPtrToTake,
+     *                             lengthOfRedPart, memoryBlockId).
+     *
+     * If the successful session data disk write completion callback is set AND we are within the maximum number of queued disk operation
+     * completion callbacks, calls LtpEngine::m_onSuccessfulBundleSendCallback() to invoke the successful session data disk write completion callback.
+     * Else, queues the callback context data to the pending successful bundle send callback context data queue.
+     * @param destinationClientServiceId The remote client service ID.
+     * @param destinationLtpEngineId The remote LTP engine ID.
+     * @param clientServiceDataToSendPtrToTake The client service data to send.
+     * @param userDataPtrToTake The attached user data.
+     * @param lengthOfRedPart The red part data length in bytes.
+     * @param memoryBlockId The memory block ID.
+     * @post The arguments to (clientServiceDataToSendPtrToTake->m_userData) and userDataPtrToTake are left in a moved-from state.
+     */
     LTP_LIB_NO_EXPORT void OnTransmissionRequestDataWrittenToDisk(uint64_t destinationClientServiceId, uint64_t destinationLtpEngineId,
         std::shared_ptr<LtpClientServiceDataToSend>& clientServiceDataToSendPtrToTake, std::shared_ptr<LtpTransmissionRequestUserData>& userDataPtrToTake,
         uint64_t lengthOfRedPart, uint64_t memoryBlockId);
 public:
-
+    /** Issue a cancellation request.
+     *
+     * If we are issuing a cancellation request as a sender AND the session does NOT exist in the active transmission sessions, returns immediately.
+     * Else, calls LtpEngine::EraseTxSession() to remove the session from the active transmission sessions.
+     * Queues a cancellation segment with a cancel code of USER_CANCELLED for transmission, then calls LtpEngine::TrySaturateSendPacketPipeline()
+     * to dequeue the cancellation segment.
+     *
+     * If we are issuing a cancellation request as a receiver AND the session does NOT exist in the active reception sessions, returns immediately.
+     * Else, if the session is safe to delete, calls ltpEngine::EraseRxSession() to remove the session from the active reception sessions, if the
+     * session is NOT safe to delete, appends it to the receivers with pending operations needing deleted queue.
+     * Queues a cancellation segment with a cancel code of USER_CANCELLED for transmission, then calls LtpEngine::TrySaturateSendPacketPipeline()
+     * to dequeue the cancellation segment.
+     * @param sessionId The session ID.
+     * @return True if a cancellation segment was queued successfully, or False otherwise.
+     */
     LTP_LIB_EXPORT bool CancellationRequest(const Ltp::session_id_t & sessionId);
+    
+    /** Initiate a request to issue a cancellation request (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpEngine::CancellationRequest().
+     * @param sessionId The session ID.
+     */
     LTP_LIB_EXPORT void CancellationRequest_ThreadSafe(const Ltp::session_id_t & sessionId);
     
+    /** Set the session start callback.
+     *
+     * @param callback The callback to set.
+     */
     LTP_LIB_EXPORT void SetSessionStartCallback(const SessionStartCallback_t & callback);
+    
+    /** Set the red data part reception callback.
+     *
+     * @param callback The callback to set.
+     */
     LTP_LIB_EXPORT void SetRedPartReceptionCallback(const RedPartReceptionCallback_t & callback);
+    
+    /** Set the green data segment reception callback.
+     *
+     * @param callback The callback to set.
+     */
     LTP_LIB_EXPORT void SetGreenPartSegmentArrivalCallback(const GreenPartSegmentArrivalCallback_t & callback);
+    
+    /** Set the reception session cancellation callback.
+     *
+     * @param callback The callback to set.
+     */
     LTP_LIB_EXPORT void SetReceptionSessionCancelledCallback(const ReceptionSessionCancelledCallback_t & callback);
+    
+    /** Set the transmission session completion callback.
+     *
+     * @param callback The callback to set.
+     */
     LTP_LIB_EXPORT void SetTransmissionSessionCompletedCallback(const TransmissionSessionCompletedCallback_t & callback);
+    
+    /** Set the initial data transmission completion callback.
+     *
+     * @param callback The callback to set.
+     */
     LTP_LIB_EXPORT void SetInitialTransmissionCompletedCallback(const InitialTransmissionCompletedCallback_t & callback);
+    
+    /** Set the transmission session cancellation callback.
+     *
+     * @param callback The callback to set.
+     */
     LTP_LIB_EXPORT void SetTransmissionSessionCancelledCallback(const TransmissionSessionCancelledCallback_t & callback);
 
+    /** Set the failed byte buffer session data disk write completion callback.
+     *
+     * @param callback The callback to set.
+     */
     LTP_LIB_EXPORT void SetOnFailedBundleVecSendCallback(const OnFailedBundleVecSendCallback_t& callback);
+    
+    /** Set the failed ZMQ session data disk write completion callback.
+     *
+     * @param callback The callback to set.
+     */
     LTP_LIB_EXPORT void SetOnFailedBundleZmqSendCallback(const OnFailedBundleZmqSendCallback_t& callback);
+    
+    /** Set the successful session disk write completion callback.
+     *
+     * @param callback The callback to set.
+     */
     LTP_LIB_EXPORT void SetOnSuccessfulBundleSendCallback(const OnSuccessfulBundleSendCallback_t& callback);
+    
+    /** Set the outduct link status event callback.
+     *
+     * @param callback The callback to set.
+     */
     LTP_LIB_EXPORT void SetOnOutductLinkStatusChangedCallback(const OnOutductLinkStatusChangedCallback_t& callback);
+    
+    /** Set the outduct UUID.
+     *
+     * @param userAssignedUuid The outduct UUID to set.
+     */
     LTP_LIB_EXPORT void SetUserAssignedUuid(uint64_t userAssignedUuid);
-
+    
+    /** Handle packet chunk reception.
+     *
+     * Calls Ltp::HandleReceivedChars() feeding the chunk to the Rx state machine for processing.
+     * If processing was NOT successful, resets the Rx state machine.
+     * Else, if the processing was successful BUT this is the last chunk of the packet AND we are NOT at the beginning state, resets the Rx state machine,
+     * the processing at this point is marked unsuccessful.
+     * If the processing operation is still in progress (due to a deferred disk write), nothing more to do, just wait until the next eventual
+     * invocation of this function which will occur in the chain of events after successful disk write completion.
+     * Else, if the processing operation has completed synchronously, calls LtpEngine::PacketInFullyProcessedCallback() with the success status
+     * of the processing.
+     * @param isLastChunkOfPacket Whether this is the last chunk of the packet.
+     * @param data The data begin pointer.
+     * @param size The data size in bytes.
+     * @param sessionOriginatorEngineIdDecodedCallbackPtr The session originator engine ID decoded callback.
+     * @return True if the processing was successful, or False otherwise.
+     */
     LTP_LIB_EXPORT bool PacketIn(const bool isLastChunkOfPacket, const uint8_t * data, const std::size_t size,
         Ltp::SessionOriginatorEngineIdDecodedCallback_t * sessionOriginatorEngineIdDecodedCallbackPtr = NULL);
+   
+    /** Handle packet chunk reception (for unit testing).
+     *
+     * For each chunk, calls LtpEngine::PacketIn(isLastChunkOfPacket, constBufferVec.data(), constBufferVec.size()) with the last buffer
+     * marked as isLastChunkOfPacket.
+     * @param constBufferVec The data chunk buffers.
+     * @return True if the processing for ALL chunks was successful, or False otherwise.
+     */
     LTP_LIB_EXPORT bool PacketIn(const std::vector<boost::asio::const_buffer> & constBufferVec); //for testing
 
+    /** Initiate a request to handle packet chunk reception (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpEngine::PacketIn(true, data, size, sessionOriginatorEngineIdDecodedCallbackPtr).
+     * @param data The data begin pointer.
+     * @param size The data size in bytes.
+     * @param sessionOriginatorEngineIdDecodedCallbackPtr The session originator engine ID decoded callback.
+     */
     LTP_LIB_EXPORT void PacketIn_ThreadSafe(const uint8_t * data, const std::size_t size, Ltp::SessionOriginatorEngineIdDecodedCallback_t * sessionOriginatorEngineIdDecodedCallbackPtr = NULL);
+    
+    /** Initiate a request to handle packet chunk reception (thread-safe) (for unit testing).
+     *
+     * Initiates an asynchronous request to LtpEngine::PacketIn(constBufferVec).
+     * @param constBufferVec The data chunk buffers.
+     */
     LTP_LIB_EXPORT void PacketIn_ThreadSafe(const std::vector<boost::asio::const_buffer> & constBufferVec); //for testing
 
+    /** Initiate a request to emit an outduct link down event (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpEngine::DoExternalLinkDownEvent().
+     */
     LTP_LIB_EXPORT void PostExternalLinkDownEvent_ThreadSafe();
-
+    
+    /** Load next packet to send.
+     *
+     * Data priority (in descending order, 1 is highest priority).
+     * 1. Senders needing deleted queue:
+     *   For each queued sender:
+     *   A. If a call to LtpSessionSender::NextTimeCriticalDataToSend() loads a new packet in:
+     *     The resulting critical data are loaded as the next packet to send and the sender is NOT popped from the queue, then returns
+     *     with a value of True (kept so consecutive invocations exhaust the critical data it has left to send).
+     *   B. If the sender does not have critical data left to send AND this is a failed session:
+     *     a. If the failed byte buffer session data disk write completion callback is set:
+     *       If the client service data to send are safe to move, calls LtpEngine::m_onFailedBundleVecSendCallback() passing them by reference.
+     *       Else, calls LtpEngine::m_onFailedBundleVecSendCallback() passing them by copy.
+     *     b. If the failed ZMQ session data disk write completion callback is set:
+     *       If the client service data to send are safe to move, calls LtpEngine::m_onFailedBundleZmqSendCallback() passing them by reference.
+     *       Else, calls LtpEngine::m_onFailedBundleZmqSendCallback() passing them by copy.
+     *   C. If the sender does not have critical data left to send AND this is NOT a failed session:
+     *     If the successful session data disk write completion callback is set AND has NOT already been invoked, calls LtpEngine::m_onSuccessfulBundleSendCallback().
+     *   D. If the sender does not have critical data left to send, regardless if this is a failed session or not:
+     *     If the session exists in the active transmission sessions, calls LtpEngine::EraseTxSession() to remove the session from the active transmission sessions.
+     *     Finally, the sender is popped from the senders needing deleted queue.
+     * 2. Pending successful bundle send callback context data queue:
+     *   While we are within the maximum number of queued disk operation completion callbacks:
+     *   A. If the successful session data disk write completion callback is set:
+     *     For each queued operation callback, calls LtpEngine::m_onSuccessfulBundleSendCallback() to invoke it, then pops it from the queue.
+     * 3. Receivers with pending operations needing deleted queue:
+     *   For each queued receiver:
+     *   A. If the session exists in the active reception sessions AND is safe to delete:
+     *     The session is transferred to the receivers needing deleted queue.
+     *   B. If the session exists in the active reception sessions AND is NOT safe to delete:
+     *     Breaks out of this branch and stops flushing the queue, meaning if not empty, the front of the queue will always be a receiver not safe to delete.
+     *   C. Finally:
+     *     The receiver is popped from the receivers with pending operations needing deleted queue.
+     * 4. Receivers needing deleted queue:
+     *   A. If the session exists in the active reception sessions AND is safe to delete:
+     *     Calls LtpEngine::EraseRxSession() to remove the session from the active reception sessions queue.
+     *   B. If the session exists in the active reception sessions AND is NOT safe to delete:
+     *     The session is transferred to the receivers with pending operations needing deleted queue.
+     *   C. Finally:
+     *     The receiver is popped from the receivers needing deleted queue.
+     * 5. Cancellation segment context data queue:
+     *   If the queue is NOT empty, the first queued cancellation segment is loaded as the next packet to send, a cancellation segment
+     *   retransmission timer is started, and the segment is popped from the queue, finally returns with a value of True.
+     * 6. Closed sessions data to send queue:
+     *   If the queue is NOT empty, the first queued segment is loaded as the next packet to send, the segment is popped from the queue,
+     *   finally returns with a value of True (no need for a retransmission timer since we are responding to a closed session).
+     * 7. Senders needing critical data sent queue:
+     *   A. If a call to LtpSessionSender::NextTimeCriticalDataToSend() loads a new packet in:
+     *     The resulting critical data are loaded as the next packet to send and the sender is NOT popped from the queue, then returns
+     *     with a value of True (kept so consecutive invocations exhaust the critical data it has left to send).
+     *   B. If the sender does NOT have critical data left to send OR the session does NOT exist in the active transmission sessions:
+     *     The sender is popped from the queue.
+     * 8. Receivers needing data sent queue:
+     *   A. If a call to LtpSessionReceiver::NextDataToSend() loads a new packet in:
+     *     The resulting data are loaded as the next packet to send and the receiver is NOT popped from the queue, then returns
+     *     with a value of True (kept so consecutive invocations exhaust the data it has left to send).
+     *   B. If the receiver does NOT have data left to send OR the session does NOT exist in the active transmission sessions:
+     *     The receiver is popped from the queue.
+     * 9. Senders needing first-pass data sent queue:
+     *   A. If a call to LtpSessionSender::NextFirstPassDataToSend() loads a new packet in:
+     *     The resulting first-pass data are loaded as the next packet to send and the sender is NOT popped from the queue, then returns
+     *     with a value of True (kept so consecutive invocations exhaust the first-pass data it has left to send).
+     *   B. If the sender does NOT have first-pass data left to send OR the session does NOT exist in the active transmission sessions:
+     *     The sender is popped from the queue.
+     * 10. [System]: If execution has reached this point.
+     *   Returns with a value of False indicating there is nothing to send and leaves the send operation context data unmodified.
+     * @param udpSendPacketInfo The send operation context data to modify.
+     * @return True if there is a packet to send and it could be loaded successfully (and thus the send operation context data are modified), or False otherwise.
+     * @post If returns True, the argument to udpSendPacketInfo is modified accordingly (see above for details).
+     */
     LTP_LIB_EXPORT bool GetNextPacketToSend(UdpSendPacketInfo& udpSendPacketInfo);
 
+    /** Get the number of active reception sessions.
+     *
+     * @return The number of active reception sessions.
+     */
     LTP_LIB_EXPORT std::size_t NumActiveReceivers() const;
+    
+    /** Get the number of active transmission sessions.
+     *
+     * @return The number of active transmission sessions.
+     */
     LTP_LIB_EXPORT std::size_t NumActiveSenders() const;
+    
+    /** Get the maximum number of sessions in pipeline.
+     *
+     * @return M_MAX_SESSIONS_IN_PIPELINE.
+     */
     LTP_LIB_EXPORT uint64_t GetMaxNumberOfSessionsInPipeline() const;
 
+    /** Set the maximum bit rate.
+     *
+     * Calls TokenRateLimiter::SetRate().
+     * (see docs for LtpEngineConfig::maxSendRateBitsPerSecOrZeroToDisable).
+     * @param maxSendRateBitsPerSecOrZeroToDisable The maximum bit rate to set.
+     */
     LTP_LIB_EXPORT void UpdateRate(const uint64_t maxSendRateBitsPerSecOrZeroToDisable);
+    
+    /** Initiate a request to set the maximum bit rate (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpEngine::UpdateRate().
+     * @param maxSendRateBitsPerSecOrZeroToDisable The maximum bit rate to set.
+     */
     LTP_LIB_EXPORT void UpdateRate_ThreadSafe(const uint64_t maxSendRateBitsPerSecOrZeroToDisable);
     
+    /** Initiate a request to set the RTT time reference across all senders/receivers (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpEngine::SetDelays().
+     * @param oneWayLightTime
+     * @param oneWayMarginTime
+     * @param updateRunningTimers
+     */
     LTP_LIB_EXPORT void SetDelays_ThreadSafe(const boost::posix_time::time_duration& oneWayLightTime, const boost::posix_time::time_duration& oneWayMarginTime, bool updateRunningTimers);
+    
+    /** Initiate a request to set the out-of-order transmission/reception compensation delays (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpEngine::SetDeferDelays().
+     * @param delaySendingOfReportSegmentsTimeMsOrZeroToDisable The delay for receivers.
+     * @param delaySendingOfDataSegmentsTimeMsOrZeroToDisable The delay for senders.
+     */
     LTP_LIB_EXPORT void SetDeferDelays_ThreadSafe(const uint64_t delaySendingOfReportSegmentsTimeMsOrZeroToDisable, const uint64_t delaySendingOfDataSegmentsTimeMsOrZeroToDisable);
+    
+    /** Initiate a request to set the MTU constraint shared across all receivers (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpEngine::SetMtuReportSegment().
+     * @param mtuReportSegment The MTU constraint to set.
+     */
     LTP_LIB_EXPORT void SetMtuReportSegment_ThreadSafe(uint64_t mtuReportSegment);
+    
+    /** Initiate a request to set the MTU constraint shared across all senders (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpEngine::SetMtuDataSegment().
+     * @param mtuDataSegment The MTU constraint to set.
+     */
     LTP_LIB_EXPORT void SetMtuDataSegment_ThreadSafe(uint64_t mtuDataSegment);
 protected:
+    /** Set the RTT time reference across all senders/receivers.
+     *
+     * Recalculates all time references affected by a change in RTT.
+     * If should update the running timers, calls LtpTimerManager::AdjustRunningTimers() on all the timer managers.
+     * @param oneWayLightTime The one way light time.
+     * @param oneWayMarginTime The one way margin time.
+     * @param updateRunningTimers Whether the change should update the currently running timers.
+     */
     LTP_LIB_EXPORT void SetDelays(const boost::posix_time::time_duration& oneWayLightTime, const boost::posix_time::time_duration& oneWayMarginTime, bool updateRunningTimers);
+    
+    /** Set the out-of-order transmission/reception compensation delays.
+     *
+     * (see docs for LtpEngineConfig::delaySendingOfReportSegmentsTimeMsOrZeroToDisable and LtpEngineConfig::delaySendingOfDataSegmentsTimeMsOrZeroToDisable).
+     * @param delaySendingOfReportSegmentsTimeMsOrZeroToDisable The delay for receivers.
+     * @param delaySendingOfDataSegmentsTimeMsOrZeroToDisable The delay for senders.
+     * @post If the receiver delay feature is disabled, delaySendingOfReportSegmentsTimeMsOrZeroToDisable is set to (boost::posix_time::special_values::not_a_date_time).
+     * @post If the sender delay feature is disabled, delaySendingOfDataSegmentsTimeMsOrZeroToDisable is set to (boost::posix_time::special_values::not_a_date_time).
+     */
     LTP_LIB_EXPORT void SetDeferDelays(const uint64_t delaySendingOfReportSegmentsTimeMsOrZeroToDisable, const uint64_t delaySendingOfDataSegmentsTimeMsOrZeroToDisable);
+    
+    /** Set the MTU constraint shared across all receivers.
+     *
+     * Calculates the maximum number of report claims per report segment.
+     * @param mtuReportSegment The MTU constraint to set.
+     */
     LTP_LIB_EXPORT void SetMtuReportSegment(uint64_t mtuReportSegment);
+    
+    /** Set the MTU constraint shared across all senders.
+     *
+     * @param mtuDataSegment The MTU constraint to set.
+     */
     LTP_LIB_EXPORT void SetMtuDataSegment(uint64_t mtuDataSegment);
 
+    /** Handle packet processing completion.
+     *
+     * Virtual function, default implementation is a no-op.
+     * @param success Whether the processing was successful.
+     */
     LTP_LIB_EXPORT virtual void PacketInFullyProcessedCallback(bool success);
+    
+    /** Perform a SendPacket operation.
+     *
+     * Virtual function, default implementation is a no-op.
+     * @param constBufferVec The data buffers to send.
+     * @param underlyingDataToDeleteOnSentCallback The underlying data buffers shared pointer.
+     * @param underlyingCsDataToDeleteOnSentCallback The underlying client service data to send shared pointer, should be nullptr.
+     */
     LTP_LIB_EXPORT virtual void SendPacket(std::vector<boost::asio::const_buffer>& constBufferVec,
         std::shared_ptr<std::vector<std::vector<uint8_t> > >& underlyingDataToDeleteOnSentCallback,
         std::shared_ptr<LtpClientServiceDataToSend>& underlyingCsDataToDeleteOnSentCallback);
+    
+    /** Perform a SendPackets operation.
+     *
+     * Virtual function, default implementation is a no-op.
+     * @param constBufferVecs The vector of data buffers to send.
+     * @param underlyingDataToDeleteOnSentCallback The vector of underlying data buffers shared pointers.
+     * @param underlyingCsDataToDeleteOnSentCallback The vector of underlying client service data to send shared pointers.
+     */
     LTP_LIB_EXPORT virtual void SendPackets(std::vector<std::vector<boost::asio::const_buffer> >& constBufferVecs,
         std::vector<std::shared_ptr<std::vector<std::vector<uint8_t> > > >& underlyingDataToDeleteOnSentCallback,
         std::vector<std::shared_ptr<LtpClientServiceDataToSend> >& underlyingCsDataToDeleteOnSentCallback);
+    
+    /** Initiate a request to handle a SendPackets operation completion (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpEngine::OnSendPacketsSystemCallCompleted_NotThreadSafe().
+     */
     LTP_LIB_EXPORT void OnSendPacketsSystemCallCompleted_ThreadSafe();
 private:
+    /** Initiate a request to saturate the send packet pipeline (thread-safe).
+     *
+     * Initiates an asynchronous request to LtpEngine::TrySaturateSendPacketPipeline().
+     */
     LTP_LIB_NO_EXPORT void SignalReadyForSend_ThreadSafe();
+    
+    /** Handle SendPackets operation completion.
+     *
+     * Calls LtpEngine::TrySaturateSendPacketPipeline() to resume processing.
+     * @post Decrements the number of pending SendPackets operations.
+     */
     LTP_LIB_NO_EXPORT void OnSendPacketsSystemCallCompleted_NotThreadSafe();
+    
+    /** Try saturate the SendPacket pipeline.
+     *
+     * Loops while ltpEngine::TrySendPacketIfAvailable().
+     */
     LTP_LIB_NO_EXPORT void TrySaturateSendPacketPipeline();
+    
+    /** Try perform a SendPacket operation.
+     *
+     * If the maximum number of pending SendPacket operations has been exceeded OR we are NOT using a dedicated I/O thread (typically in
+     * unit tests), returns immediately.
+     * Else, the processing goes as follows:
+     * 1. If rate limiting is enabled and we CANNOT take tokens to process at the moment:
+     *   There is nothing to send for now, calls LtpEngine::TryRestartTokenRefreshTimer() to restart the token refresh timer, which will then call
+     *   this function when tokens are available for processing.
+     * 2. If there are tokens to process AND batch processing is NOT enabled:
+     *   A. If a call to LtpEngine::GetNextPacketToSend() does NOT load new data to send (there are no data available to send):
+     *     No further processing is required.
+     *   B. If there are data to send AND rate limiting is enabled:
+     *     Takes N tokens from the rate limiter and calls LtpEngine::TryRestartTokenRefreshTimer() to restart the token refresh timer.
+     *   C. Finally:
+     *     If the data to send need to be read from disk, calls MemoryInFiles::ReadMemoryAsync() to initiate a deferred disk single-read with
+     *     LtpEngine::OnDeferredReadCompleted() as the completion handler.
+     *     Else, if the data are already in-memory, calls LtpEngine::SendPacket() on the data loaded for sending.
+     * 3. If there are tokens to process AND batch processing is enabled:
+     *   For each packet that could be loaded by successive calls to LtpEngine::GetNextPacketToSend() up until the configured maximum number
+     *   of packets per system call, performs the same processing as (branch 2) on a multi-packet scale, meaning if data need to be read from
+     *   disk, calls MemoryInFiles::ReadMemoryAsync() with LtpEngine::OnDeferredMultiReadCompleted() as the completion handler or if all data
+     *   are already in-memory, calls LtpEngine::SendPackets() instead.
+     * 4. If we are using the disk for intermediate storage AND there are memory blocks queued for deletion:
+     *   For each memory block queued for deletion, calls MemoryInFiles::DeleteMemoryBlock() and pops it from the queue.
+     * @return The number of JUST NOW SendPacket operations queued successfully.
+     * @post Advances the number of pending SendPackets operations accordingly (see above for details).
+     */
     LTP_LIB_NO_EXPORT bool TrySendPacketIfAvailable();
+    
+    /** Handle deferred disk single-read operation.
+     *
+     * If the single-read operation was successful, calls SendPacket(constBufferVec, underlyingDataToDeleteOnSentCallback, nullClientServiceData).
+     * @param success Whether the single-read operation was successful.
+     * @param constBufferVec The data buffers to send.
+     * @param underlyingDataToDeleteOnSentCallback The underlying data buffers shared pointer.
+     */
     LTP_LIB_NO_EXPORT void OnDeferredReadCompleted(bool success, std::vector<boost::asio::const_buffer>& constBufferVec,
         std::shared_ptr<std::vector<std::vector<uint8_t> > >& underlyingDataToDeleteOnSentCallback);
+    
+    /** Handle deferred disk multi-read operation.
+     *
+     * If the multi-read operation was successful, calls LtpEngine::SendPackets(constBufferVecs, underlyingDataToDeleteOnSentCallbackVec, underlyingCsDataToDeleteOnSentCallbackVec).
+     * @param success Whether the multi-read operation was successful.
+     * @param constBufferVecs The vector of data buffers to send.
+     * @param underlyingDataToDeleteOnSentCallbackVec The vector of underlying data buffers shared pointers.
+     * @param underlyingCsDataToDeleteOnSentCallbackVec The vector of underlying client service data to send shared pointers.
+     */
     LTP_LIB_NO_EXPORT void OnDeferredMultiReadCompleted(bool success, std::vector<std::vector<boost::asio::const_buffer> >& constBufferVecs,
         std::vector<std::shared_ptr<std::vector<std::vector<uint8_t> > > >& underlyingDataToDeleteOnSentCallbackVec,
         std::vector<std::shared_ptr<LtpClientServiceDataToSend> >& underlyingCsDataToDeleteOnSentCallbackVec);
 
+    /** Handle cancellation segment reception.
+     *
+     * If the segment was issued by the sender AND the target session exists in the active reception sessions, if the cancellation callback is set
+     * AND has NOT already been invoked for this session, calls LtpEngine::m_receptionSessionCancelledCallback() with a cancel code of reasonCode
+     * to invoke the cancellation callback.
+     * If the session is safe to delete calls LtpEngine::EraseRxSession() to delete the session immediately, else appends the session to the receivers
+     * with pending operations needing deleted queue.
+     *
+     * If the segment was issued by the receiver AND the target session exists in the active transmission sessions, if the cancellation callback is set
+     * AND has NOT already been invoked for this session, calls LtpEngine::m_transmissionSessionCancelledCallback() with a cancel code of reasonCode
+     * to invoke the cancellation callback.
+     * Calls LtpEngine::EraseTxSession() to delete the session.
+     *
+     * Appends a cancellation acknowledgment segment to the closed sessions data to send queue.
+     * Calls LtpEngine::TrySaturateSendPacketPipeline() to resume processing.
+     * @param sessionId The session ID.
+     * @param reasonCode The reason code.
+     * @param isFromSender Whether the cancellation segment was issued by the sender (if False, issued by receiver).
+     * @param headerExtensions The LTP header extensions.
+     * @param trailerExtensions The LTP trailer extensions.
+     */
     LTP_LIB_NO_EXPORT void CancelSegmentReceivedCallback(const Ltp::session_id_t & sessionId, CANCEL_SEGMENT_REASON_CODES reasonCode, bool isFromSender,
         Ltp::ltp_extensions_t & headerExtensions, Ltp::ltp_extensions_t & trailerExtensions);
+    
+    /** Handle cancellation acknowledgment segment reception.
+     *
+     * If the segment is directed to the sender and the session originator ID is NOT our engine ID, returns immediately.
+     * If the segment is directed to the receiver and the session originator ID is our engine ID (same-engine transfer), returns immediately.
+     * Deletes the cancellation segment retransmission timer for the associated cancellation segment.
+     * If the segment is directed to the sender AND this is a ping segment, sets the next ping expiry, then if the
+     * outduct link status event callback is set, calls LtpEngine::m_onOutductLinkStatusChangedCallback(false, uuid) to emit an outduct link up event.
+     * Else, if the segment is directed to the receiver AND the associated cancellation segment has a cancel code of UNREACHABLE, removes the session
+     * from the sessions with wrong client service ID queue.
+     * @param sessionId The session ID.
+     * @param isToSender Whether the cancellation acknowledgment segment is directed to the sender (if False, directed to receiver).
+     * @param headerExtensions The LTP header extensions.
+     * @param trailerExtensions The LTP trailer extensions.
+     * @post If this is an expired ping segment, M_NEXT_PING_START_EXPIRY is set to (now() + M_SENDER_PING_TIME).
+     */
     LTP_LIB_NO_EXPORT void CancelAcknowledgementSegmentReceivedCallback(const Ltp::session_id_t & sessionId, bool isToSender,
         Ltp::ltp_extensions_t & headerExtensions, Ltp::ltp_extensions_t & trailerExtensions);
+    
+    /** Handle report acknowledgment segment reception.
+     *
+     * If the session originator ID is our engine ID (same-engine transfer), returns immediately.
+     * If the target session exists in the active reception sessions, calls LtpSessionReceiver::ReportAcknowledgementSegmentReceivedCallback().
+     * Calls LtpEngine::TrySaturateSendPacketPipeline() to resume processing.
+     * @param sessionId The session ID.
+     * @param reportSerialNumberBeingAcknowledged The associated report serial number.
+     * @param headerExtensions The LTP header extensions.
+     * @param trailerExtensions The LTP trailer extensions.
+     */
     LTP_LIB_NO_EXPORT void ReportAcknowledgementSegmentReceivedCallback(const Ltp::session_id_t & sessionId, uint64_t reportSerialNumberBeingAcknowledged,
         Ltp::ltp_extensions_t & headerExtensions, Ltp::ltp_extensions_t & trailerExtensions);
+    
+    /** Handle report segment reception.
+     *
+     * If the session originator ID is our engine ID (same-engine transfer), returns immediately.
+     * If the target session exists in the active transmission sessions, calls LtpSessionSender::ReportSegmentReceivedCallback().
+     * Else, appends a report acknowledgment segment to the closed sessions data to send queue.
+     * Calls LtpEngine::TrySaturateSendPacketPipeline() to resume processing.
+     * @param sessionId The session ID.
+     * @param reportSegment The report segment.
+     * @param headerExtensions The LTP header extensions.
+     * @param trailerExtensions The LTP trailer extensions.
+     */
     LTP_LIB_NO_EXPORT void ReportSegmentReceivedCallback(const Ltp::session_id_t & sessionId, const Ltp::report_segment_t & reportSegment,
         Ltp::ltp_extensions_t & headerExtensions, Ltp::ltp_extensions_t & trailerExtensions);
-    //return true if operation is ongoing (possibly due to disk writes),
-    // false if operation is done (and udp packet circular buffer can reduce its size)
+
+    /** Handle data segment reception.
+     *
+     * If the session originator ID is our engine ID (same-engine transfer), returns immediately.
+     * If the data segment destination client service ID is NOT our local client service ID, appends the session to the sessions with wrong client
+     * service ID queue, then (only the first time) a cancellation segment is queued with a cancel code of UNREACHABLE, if the cancellation
+     * callback is set, calls LtpEngine::m_receptionSessionCancelledCallback() with the same cancel code to invoke the cancellation callback,
+     * finally calls LtpEngine::TrySaturateSendPacketPipeline() to dequeue the cancellation segment.
+     * If a session with the segment session ID does NOT already exist, a new reception session is added to the active reception sessions
+     * UNLESS the session recreation preventer feature is enabled and the session ID is currently in quarantine, if a new session is created AND
+     * the session start callback is set, calls LtpEngine::m_sessionStartCallback() to invoke the session start callback.
+     * Calls LtpSessionReceiver::DataSegmentReceivedCallback() eventually returning its return value if execution has reached this point.
+     * Calls LtpEngine::TrySaturateSendPacketPipeline() to resume processing.
+     * @param segmentTypeFlags The data segment type.
+     * @param sessionId The session ID.
+     * @param clientServiceDataVec The client service data.
+     * @param dataSegmentMetadata The data segment metadata.
+     * @param headerExtensions The LTP header extensions.
+     * @param trailerExtensions The LTP trailer extensions.
+     * @return True if the operation is still in progress on function exit (currently only on asynchronous disk writes), or False otherwise.
+     * @post If returns False, indicates that the UDP circular index buffer can reduce its size.
+     */
     LTP_LIB_NO_EXPORT bool DataSegmentReceivedCallback(uint8_t segmentTypeFlags, const Ltp::session_id_t & sessionId,
         std::vector<uint8_t> & clientServiceDataVec, const Ltp::data_segment_metadata_t & dataSegmentMetadata,
         Ltp::ltp_extensions_t & headerExtensions, Ltp::ltp_extensions_t & trailerExtensions);
 
+    /** Handle cancellation segment retransmission timer expiry.
+     *
+     * If the transmission retry count is within the retransmission limit per serial number, the cancellation segment is queued back for retransmission,
+     * the retry count is incremented, then calls LtpEngine::TrySaturateSendPacketPipeline() to dequeue the cancellation segment.
+     * Else, if this is (an expired) ping segment (see docs for LtpEngine::OnHousekeeping_TimerExpired), sets the next ping expiry, then if the
+     * outduct link status event callback is set, calls LtpEngine::m_onOutductLinkStatusChangedCallback(true, uuid) to emit an outduct link down event.
+     * @param cancelSegmentTimerSerialNumber The session ID.
+     * @param userData The cancellation segment context data.
+     * @post If this is an expired ping segment, M_NEXT_PING_START_EXPIRY is set to (now() + M_SENDER_PING_TIME).
+     */
     LTP_LIB_NO_EXPORT void CancelSegmentTimerExpiredCallback(Ltp::session_id_t cancelSegmentTimerSerialNumber, std::vector<uint8_t> & userData);
+    
+    /** Handle sender should be queued for deletion event.
+     *
+     * If the session was cancelled, a cancellation segment is queued with a cancel code of reasonCode and if the cancellation callback is set AND
+     * has NOT already been invoked for this session, calls LtpEngine::m_transmissionSessionCancelledCallback() with the same cancel code to invoke
+     * the cancellation callback.
+     * Else, if the session was closed, calls LtpEngine::m_transmissionSessionCompletedCallback() as the cancellation callback.
+     *
+     * Regardless if the session was cancelled or closed, queues the sender for deletion in the senders needing deleted queue,
+     * then calls LtpEngine::SignalReadyForSend_ThreadSafe() on behalf of the sender.
+     * @param sessionId The session ID.
+     * @param wasCancelled Whether the session was cancelled (if False, session was closed).
+     * @param reasonCode The cancel code.
+     * @param userDataPtr The session attached client service data.
+     */
     LTP_LIB_NO_EXPORT void NotifyEngineThatThisSenderNeedsDeletedCallback(const Ltp::session_id_t & sessionId, bool wasCancelled, CANCEL_SEGMENT_REASON_CODES reasonCode, std::shared_ptr<LtpTransmissionRequestUserData> & userDataPtr);
+    
+    /** Handle sender has data to send event.
+     *
+     * Appends the sender to the senders needing critical data sent queue, then calls LtpEngine::SignalReadyForSend_ThreadSafe() on behalf of the sender.
+     * @param sessionNumber The session number.
+     */
     LTP_LIB_NO_EXPORT void NotifyEngineThatThisSenderHasProducibleData(const uint64_t sessionNumber);
+    
+    /** Handle receiver should be queued for deletion event.
+     *
+     * If the session was cancelled, a cancellation segment is queued with a cancel code of reasonCode and if the cancellation callback is set
+     * AND has NOT already been invoked for this session, calls LtpEngine::m_receptionSessionCancelledCallback() with the same cancel code
+     * to invoke the cancellation callback.
+     *
+     * Regardless if the session was cancelled or closed, queues the receiver for deletion in the appropriate deletion queue,
+     * then calls LtpEngine::SignalReadyForSend_ThreadSafe() on behalf of the receiver.
+     * @param sessionId The session ID.
+     * @param wasCancelled Whether the session was cancelled (if False, session was closed).
+     * @param reasonCode The cancel code.
+     */
     LTP_LIB_NO_EXPORT void NotifyEngineThatThisReceiverNeedsDeletedCallback(const Ltp::session_id_t & sessionId, bool wasCancelled, CANCEL_SEGMENT_REASON_CODES reasonCode);
+    
+    /** Handle receiver has data to send event.
+     *
+     * Appends the receiver to the receivers needing data sent queue, then calls LtpEngine::SignalReadyForSend_ThreadSafe() on behalf of the receiver.
+     * @param sessionId The session ID.
+     */
     LTP_LIB_NO_EXPORT void NotifyEngineThatThisReceiversTimersHasProducibleData(const Ltp::session_id_t & sessionId);
+    
+    /** Handle engine deferred disk operation completion.
+     *
+     * Calls LtpEngine::PacketInFullyProcessedCallback(true).
+     */
     LTP_LIB_NO_EXPORT void NotifyEngineThatThisReceiverCompletedDeferredOperation();
+    
+    /** Handle initial data transmission (first pass) completion.
+     *
+     * If the initial data transmission callback is set, calls LtpEngine::m_initialTransmissionCompletedCallbackForUser() to invoke the initial
+     * data transmission callback.
+     * @param sessionId The session ID.
+     * @param userDataPtr The session attached client service data.
+     */
     LTP_LIB_NO_EXPORT void InitialTransmissionCompletedCallback(const Ltp::session_id_t & sessionId, std::shared_ptr<LtpTransmissionRequestUserData> & userDataPtr);
 
+    /** Try restart the token refresh timer.
+     *
+     * If the token refresh timer is already running, returns immediately.
+     * Else, starts the token refresh timer asynchronously with LtpEngine::OnTokenRefresh_TimerExpired() as a completion handler.
+     */
     LTP_LIB_NO_EXPORT void TryRestartTokenRefreshTimer();
+    
+    /** Try restart the token refresh timer from the given time point.
+     *
+     * If the token refresh timer is already running, returns immediately.
+     * Else, starts the token refresh timer asynchronously with LtpEngine::OnTokenRefresh_TimerExpired() as a completion handler.
+     * @param nowPtime The time point to try restart from.
+     */
     LTP_LIB_NO_EXPORT void TryRestartTokenRefreshTimer(const boost::posix_time::ptime & nowPtime);
+    
+    /** Handle token refresh timer expiry.
+     *
+     * Calls TokenRateLimiter::AddTime(now() - m_lastTimeTokensWereRefreshed) to tick the token rate limiter.
+     * If the expiry occurred due to the timer being manually cancelled, returns immediately.
+     * Else, if more tokens can be added, calls LtpEngine::TryRestartTokenRefreshTimer(now()) to asynchronously restart the token refresh timer and
+     * let the next invocation add more tokens to the token rate limiter.
+     * Calls LtpEngine::TrySaturateSendPacketPipeline() to resume processing.
+     * @param e The error code.
+     */
     LTP_LIB_NO_EXPORT void OnTokenRefresh_TimerExpired(const boost::system::error_code& e);
 
+    /** Handle housekeeping timer expiry.
+     *
+     * If the expiry occurred due to the timer being manually cancelled, returns immediately.
+     * Else, for each reception session, if enough time has passed that the session should now be considered stagnant AND has no active pending timers,
+     * the receiver is queued for deletion in the appropriate deletion queue, then a cancellation segment is queued with a cancel code of USER_CANCELLED
+     * and if the cancellation callback is set AND has NOT already been invoked for this session, calls LtpEngine::m_receptionSessionCancelledCallback() with
+     * the same cancel code to invoke the cancellation callback.
+     * Calls LtpEngine::TrySaturateSendPacketPipeline() to dequeue any queued cancellation segments.
+     *
+     * If pinging is enabled for this engine, if we are in a no data segment activity window AND we are overdue a ping, a ping segment is queued,
+     * then calls LtpEngine::TrySaturateSendPacketPipeline() to dequeue the request.
+     * (A ping segment is implemented as a cancellation segment of a known non-existent session number (typically supplied
+     * by LtpRandomNumberGenerator::GetPingSession64() or the 32-bit variant), for which the receiver shall respond with a cancellation acknowledgment
+     * in order to determine if the link is active, a link down event callback will be called if no acknowledgment is received
+     * within a time window of (RTT * maxRetriesPerSerialNumber)).
+     *
+     * Starts the housekeeping timer asynchronously with itself as a completion handler to achieve to achieve a housekeeping interval.
+     * @param e The error code.
+     * @post If a ping segment is queued, M_NEXT_PING_START_EXPIRY is set to (boost::posix_time::special_values::pos_infin).
+     */
     LTP_LIB_NO_EXPORT void OnHousekeeping_TimerExpired(const boost::system::error_code& e);
 
+    /** Emit an outduct link down event.
+     *
+     * If the outduct link status event callback is set, calls LtpEngine::m_onOutductLinkStatusChangedCallback(true, uuid) to emit
+     * an outduct link down event.
+     */
     LTP_LIB_NO_EXPORT void DoExternalLinkDownEvent();
-
+    
     //these four functions eliminate need for each session to have its own expensive boost::function/boost::bind using a reinterpret_cast of classPtr
+    /** Handle report retransmission timer expiry.
+     *
+     * Calls LtpSessionReceiver::LtpReportSegmentTimerExpiredCallback().
+     * @param classPtr Type-erased receiver pointer.
+     * @param reportSerialNumberPlusSessionNumber The report serial number.
+     * @param userData The report retransmission timer context data.
+     */
     LTP_LIB_NO_EXPORT void LtpSessionReceiverReportSegmentTimerExpiredCallback(void* classPtr, const Ltp::session_id_t& reportSerialNumberPlusSessionNumber, std::vector<uint8_t>& userData);
+    
+    //these four functions eliminate need for each session to have its own expensive boost::function/boost::bind using a reinterpret_cast of classPtr
+    /** Handle pending checkpoint delayed report transmission timer expiry.
+     *
+     * Calls LtpSessionReceiver::LtpDelaySendReportSegmentTimerExpiredCallback().
+     * @param classPtr Type-erased receiver pointer.
+     * @param checkpointSerialNumberPlusSessionNumber The associated checkpoint serial number.
+     * @param userData The pending checkpoint delayed report transmission timer context data.
+     */
     LTP_LIB_NO_EXPORT void LtpSessionReceiverDelaySendReportSegmentTimerExpiredCallback(void* classPtr, const Ltp::session_id_t& checkpointSerialNumberPlusSessionNumber, std::vector<uint8_t>& userData);
+    
+    //these four functions eliminate need for each session to have its own expensive boost::function/boost::bind using a reinterpret_cast of classPtr
+    /** Handle checkpoint retransmission timer expiry.
+     *
+     * Calls LtpSessionSender::LtpCheckpointTimerExpiredCallback().
+     * @param classPtr Type-erased sender pointer.
+     * @param checkpointSerialNumberPlusSessionNumber The checkpoint session ID.
+     * @param userData The checkpoint retransmission timer context data.
+     */
     LTP_LIB_NO_EXPORT void LtpSessionSenderCheckpointTimerExpiredCallback(void* classPtr, const Ltp::session_id_t& checkpointSerialNumberPlusSessionNumber, std::vector<uint8_t>& userData);
+    
+    //these four functions eliminate need for each session to have its own expensive boost::function/boost::bind using a reinterpret_cast of classPtr
+    /** Handle data segment retransmission timer expiry.
+     *
+     * Calls LtpSessionSender::LtpDelaySendDataSegmentsTimerExpiredCallback().
+     * @param classPtr Type-erased sender pointer.
+     * @param sessionNumber The session number.
+     * @param userData The data segment retransmission timer context data.
+     */
     LTP_LIB_NO_EXPORT void LtpSessionSenderDelaySendDataSegmentsTimerExpiredCallback(void* classPtr, const uint64_t& sessionNumber, std::vector<uint8_t>& userData);
 private:
+    /// Rx state machine
     Ltp m_ltpRxStateMachine;
+    /// Random number generator
     LtpRandomNumberGenerator m_rng;
+    /// Our engine ID
     const uint64_t M_THIS_ENGINE_ID;
+    /// Number of pending SendPackets operations
     unsigned int m_numSendPacketsPendingSystemCalls;
 protected:
+    /// Maximum number of UDP packets to send per system call, if (M_MAX_UDP_PACKETS_TO_SEND_PER_SYSTEM_CALL > 1) enables batch sending
     const uint64_t M_MAX_UDP_PACKETS_TO_SEND_PER_SYSTEM_CALL;
 private:
+    /// RTT duration, ((oneWayLightTime * 2) + (oneWayMarginTime * 2)) where margin time is the estimated processing time overhead by the LTP engine
     boost::posix_time::time_duration m_transmissionToAckReceivedTime;
+    /// Delayed report transmission duration, the duration to wait before transmitting reports after reception of data segments filling pending gaps,
+    /// if this feature is disabled, the value is set to (boost::posix_time::special_values::not_a_date_time)
+    /// (see docs for LtpEngineConfig::delaySendingOfReportSegmentsTimeMsOrZeroToDisable)
     boost::posix_time::time_duration m_delaySendingOfReportSegmentsTime;
+    /// Delayed segment retransmission duration, the duration to wait before retransmitting data segments after reception of a report,
+    /// if this feature is disabled the value is set to (boost::posix_time::special_values::not_a_date_time)
+    /// (see docs for LtpEngineConfig::delaySendingOfDataSegmentsTimeMsOrZeroToDisable).
     boost::posix_time::time_duration m_delaySendingOfDataSegmentsTime;
+    /// Housekeeping timer interval
     const boost::posix_time::time_duration M_HOUSEKEEPING_INTERVAL;
+    /// Stagnated reception session duration, when (last received segment timestamp <= (now() - m_stagnantRxSessionTime) AND no active pending timers)
+    /// indicates the reception session has stagnated and should be queued for deletion.
     boost::posix_time::time_duration m_stagnantRxSessionTime;
+    /// Whether the engine is generating 32-bit random numbers (see docs for LtpEngineConfig::force32BitRandomNumbers for standard compliance and bandwidth details)
     const bool M_FORCE_32_BIT_RANDOM_NUMBERS;
+    /// Number of seconds between ltp session sender pings during times of zero data segment activity, if 0 this feature is disabled
     const uint64_t M_SENDER_PING_SECONDS_OR_ZERO_TO_DISABLE;
+    /// Ping interval duration, will be zero-length if pinging is disabled
     const boost::posix_time::time_duration M_SENDER_PING_TIME;
+    /// Next ping time point, if pings are enabled and (now() >= M_NEXT_PING_START_EXPIRY) indicates the next ping should be sent
     boost::posix_time::ptime M_NEXT_PING_START_EXPIRY;
+    /// Whether the previous transmission request should count as a ping (toggle), when True the next queued ping should be skipped and the toggle disabled
     bool m_transmissionRequestServedAsPing;
+    /// Maximum number of concurrent active sessions
     const uint64_t M_MAX_SIMULTANEOUS_SESSIONS;
-    const uint64_t M_MAX_SESSIONS_IN_PIPELINE; //less than (for disk) or equal to (for memory) M_MAX_SIMULTANEOUS_SESSIONS
+    /// Maximum number of sessions in pipeline, less than (for disk) or equal to (for memory) M_MAX_SIMULTANEOUS_SESSIONS
+    const uint64_t M_MAX_SESSIONS_IN_PIPELINE;
+    /// Maximum number of queued disk operation completion callbacks, set to (M_MAX_SIMULTANEOUS_SESSIONS - M_MAX_SESSIONS_IN_PIPELINE)
     const uint64_t M_DISK_BUNDLE_ACK_CALLBACK_LIMIT;
-    const uint64_t M_MAX_RX_DATA_SEGMENT_HISTORY_OR_ZERO_DISABLE;//rxDataSegmentSessionNumberRecreationPreventerHistorySizeOrZeroToDisable
+    /// Session recreation preventer maximum number of session numbers to remember, if 0 this feature is disabled
+    /// (see docs for LtpEngineConfig::rxDataSegmentSessionNumberRecreationPreventerHistorySizeOrZeroToDisable).
+    const uint64_t M_MAX_RX_DATA_SEGMENT_HISTORY_OR_ZERO_DISABLE;
+    /// Random device
     boost::random_device m_randomDevice;
 
     //session receiver functions to be passed in AS REFERENCES (note declared before m_mapSessionIdToSessionReceiver so destroyed after map)
+    /// This receiver should be queued for deletion notice function
     NotifyEngineThatThisReceiverNeedsDeletedCallback_t m_notifyEngineThatThisReceiverNeedsDeletedCallback;
+    /// This receiver has data to send notice function
     NotifyEngineThatThisReceiversTimersHasProducibleDataFunction_t m_notifyEngineThatThisReceiversTimersHasProducibleDataFunction;
+    /// This receiver has completed a deferred disk operation notice function
     NotifyEngineThatThisReceiverCompletedDeferredOperationFunction_t m_notifyEngineThatThisReceiverCompletedDeferredOperationFunction;
 
     //session sender functions to be passed in AS REFERENCES (note declared before m_mapSessionNumberToSessionSender so destroyed after map)
+    /// This sender should be queued for deletion notice function
     NotifyEngineThatThisSenderNeedsDeletedCallback_t m_notifyEngineThatThisSenderNeedsDeletedCallback;
+    /// This sender has data to send notice function
     NotifyEngineThatThisSenderHasProducibleDataFunction_t m_notifyEngineThatThisSenderHasProducibleDataFunction;
-    InitialTransmissionCompletedCallback_t m_initialTransmissionCompletedCallbackCalledBySender; //which then calls m_initialTransmissionCompletedCallbackForUser
+    /// This sender has completed initial data transmission (first pass) notice function, which then calls LtpEngine::m_initialTransmissionCompletedCallbackForUser
+    InitialTransmissionCompletedCallback_t m_initialTransmissionCompletedCallbackCalledBySender;
 
+    /// Type of map holding transmission sessions, mapped by session number
     typedef std::unordered_map<uint64_t, LtpSessionSender> map_session_number_to_session_sender_t;
+    /// Type of map holding reception sessions, mapped by session ID, hashed by session ID
     typedef std::unordered_map<Ltp::session_id_t, LtpSessionReceiver, Ltp::hash_session_id_t > map_session_id_to_session_receiver_t;
+    /// Active transmission sessions, mapped by session number
     map_session_number_to_session_sender_t m_mapSessionNumberToSessionSender;
+    /// Active reception sessions, mapped by session ID, hashed by session ID
     map_session_id_to_session_receiver_t m_mapSessionIdToSessionReceiver;
+    /** Remove given transmission session.
+     *
+     * Removes transmission session from the active transmission sessions, then if using the disk for intermediate storage
+     * queues its memory block for deletion.
+     * @param txSessionIt The transmission session iterator.
+     */
     LTP_LIB_NO_EXPORT void EraseTxSession(map_session_number_to_session_sender_t::iterator& txSessionIt);
+    /** Remove given reception session.
+     *
+     * Removes reception session from the active reception sessions.
+     * @param rxSessionIt The reception session iterator.
+     */
     LTP_LIB_NO_EXPORT void EraseRxSession(map_session_id_to_session_receiver_t::iterator& rxSessionIt);
     
+    /// Sessions with wrong client service ID, all sessions cancelled with a cancel code of UNREACHABLE, on CAx should remove the associated session
     std::set<Ltp::session_id_t> m_ltpSessionsWithWrongClientServiceId;
+    /// Closed sessions data to send queue, (session originator engine ID TO data to send), typically sending acknowledgment segments
     std::queue<std::pair<uint64_t, std::vector<uint8_t> > > m_queueClosedSessionDataToSend; //sessionOriginatorEngineId, data
+    /// Cancellation segment context data queue, feeds timers managed by m_timeManagerOfCancelSegments
     std::queue<cancel_segment_timer_info_t> m_queueCancelSegmentTimerInfo;
+    /// Senders needing deleted queue
     std::queue<uint64_t> m_queueSendersNeedingDeleted;
+    /// Senders needing critical data sent queue
     std::queue<uint64_t> m_queueSendersNeedingTimeCriticalDataSent;
+    /// Senders needing first-pass data sent queue
     std::queue<uint64_t> m_queueSendersNeedingFirstPassDataSent;
+    /// Receivers needing deleted queue
     std::queue<Ltp::session_id_t> m_queueReceiversNeedingDeleted;
+    /// Receivers with pending operations needing deleted queue
     std::queue<Ltp::session_id_t> m_queueReceiversNeedingDeletedButUnsafeToDelete;
+    /// Receivers needing data sent queue
     std::queue<Ltp::session_id_t> m_queueReceiversNeedingDataSent;
 
+    /// Session start callback
     SessionStartCallback_t m_sessionStartCallback;
+    /// Red data part reception callback
     RedPartReceptionCallback_t m_redPartReceptionCallback;
+    /// Green data segment reception callback
     GreenPartSegmentArrivalCallback_t m_greenPartSegmentArrivalCallback;
+    /// Reception session cancellation callback
     ReceptionSessionCancelledCallback_t m_receptionSessionCancelledCallback;
+    /// Transmission session completion callback
     TransmissionSessionCompletedCallback_t m_transmissionSessionCompletedCallback;
+    /// Initial data transmission (first pass) completion callback
     InitialTransmissionCompletedCallback_t m_initialTransmissionCompletedCallbackForUser;
+    /// Transmission session cancellation callback
     TransmissionSessionCancelledCallback_t m_transmissionSessionCancelledCallback;
 
+    /// Failed byte buffer session data disk write completion callback, when this is a Byte Buffer session (see client service data states in LtpClientServiceDataToSend),
+    /// when (m_onFailedBundleZmqSendCallback != NULL) indicates the user wants to retrieve the client service data to handle failure.
     OnFailedBundleVecSendCallback_t m_onFailedBundleVecSendCallback;
+    /// Failed ZMQ session data disk write completion callback, when this is a ZMQ session (see client service data states in LtpClientServiceDataToSend),
+    /// when (m_onFailedBundleZmqSendCallback != NULL) indicates the user wants to retrieve the client service data to handle failure.
     OnFailedBundleZmqSendCallback_t m_onFailedBundleZmqSendCallback;
+    /// Successful session data disk write completion callback, invoked when the session was fully written to disk and NOT when the red part reception is completed
+    /// (see comment in LtpEngine::OnTransmissionRequestDataWrittenToDisk for more details).
     OnSuccessfulBundleSendCallback_t m_onSuccessfulBundleSendCallback;
+    /// Outduct link status event callback
     OnOutductLinkStatusChangedCallback_t m_onOutductLinkStatusChangedCallback;
+    /// Outduct UUID
     uint64_t m_userAssignedUuid;
 
+    /// Maximum number of retries/resends of a single LTP packet with a serial number before the session is terminated
     uint32_t m_maxRetriesPerSerialNumber;
 protected:
+    /// I/O execution context
     boost::asio::io_service m_ioServiceLtpEngine; //for timers and post calls only
 private:
+    /// Explicit work controller for m_ioServiceLtpEngine, allows for graceful shutdown of running tasks
     std::unique_ptr<boost::asio::io_service::work> m_workLtpEnginePtr;
 
+    /// Report retransmission timer, managed by m_timeManagerOfReportSerialNumbers
     boost::asio::deadline_timer m_deadlineTimerForTimeManagerOfReportSerialNumbers;
     // within a session would normally be LtpTimerManager<uint64_t, std::hash<uint64_t> > m_timeManagerOfReportSerialNumbers;
     // but now sharing a single LtpTimerManager among all sessions, so use a
@@ -261,16 +1058,22 @@ private:
     //  sessionOriginatorEngineId = REPORT serial number
     //  sessionNumber = the session number
     //  since this is a receiver, the real sessionOriginatorEngineId is constant among all receiving sessions and is not needed
+    /// Report retransmission timer manager, timer mapped by session ID, hashed by session ID
     LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t> m_timeManagerOfReportSerialNumbers;
+    /// Report retransmission timer expiry callback
     LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t>::LtpTimerExpiredCallback_t m_rsnTimerExpiredCallback;
 
+    /// Pending checkpoint delayed report transmission timer, managed by m_timeManagerOfSendingDelayedReceptionReports
     boost::asio::deadline_timer m_deadlineTimerForTimeManagerOfSendingDelayedReceptionReports;
     //  sessionOriginatorEngineId = CHECKPOINT serial number to which RS pertains
     //  sessionNumber = the session number
     //  since this is a receiver, the real sessionOriginatorEngineId is constant among all receiving sessions and is not needed
+    /// Pending checkpoint delayed report transmission timer manager, timer mapped by session ID, hashed by session ID
     LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t> m_timeManagerOfSendingDelayedReceptionReports;
+    /// Pending checkpoint delayed report transmission timer expiry callback
     LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t>::LtpTimerExpiredCallback_t m_delayedReceptionReportTimerExpiredCallback;
 
+    /// Checkpoint retransmission timer, managed by m_timeManagerOfCheckpointSerialNumbers
     boost::asio::deadline_timer m_deadlineTimerForTimeManagerOfCheckpointSerialNumbers;
     // within a session would normally be LtpTimerManager<uint64_t, std::hash<uint64_t> > m_timeManagerOfCheckpointSerialNumbers;
     // but now sharing a single LtpTimerManager among all sessions, so use a
@@ -279,9 +1082,12 @@ private:
     //  sessionOriginatorEngineId = CHECKPOINT serial number
     //  sessionNumber = the session number
     //  since this is a sender, the real sessionOriginatorEngineId is constant among all sending sessions and is not needed
+    /// Checkpoint retransmission timer manager, timer mapped by session ID, hashed by session ID
     LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t> m_timeManagerOfCheckpointSerialNumbers;
+    /// Checkpoint retransmission timer expiry callback
     LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t>::LtpTimerExpiredCallback_t m_csnTimerExpiredCallback;
 
+    /// Data segment retransmission timer, managed by m_timeManagerOfSendingDelayedDataSegments
     boost::asio::deadline_timer m_deadlineTimerForTimeManagerOfSendingDelayedDataSegments;
     // within a session would normally be a single deadline timer;
     // but now sharing a single LtpTimerManager among all sessions, so use a
@@ -289,57 +1095,91 @@ private:
     // such that: 
     //  uint64_t = the session number
     //  since this is a sender, the real sessionOriginatorEngineId is constant among all sending sessions and is not needed
+    /// Data segment retransmission timer manager, timer mapped by session number, hashed by session number
     LtpTimerManager<uint64_t, std::hash<uint64_t> > m_timeManagerOfSendingDelayedDataSegments;
+    /// Data segment retransmission timer expiry callback
     LtpTimerManager<uint64_t, std::hash<uint64_t> >::LtpTimerExpiredCallback_t m_delayedDataSegmentsTimerExpiredCallback;
 
+    /// Cancellation segment retransmission timer expiry callback
     LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t>::LtpTimerExpiredCallback_t m_cancelSegmentTimerExpiredCallback;
+    /// Cancellation segment retransmission timer, managed by m_timeManagerOfCancelSegments
     boost::asio::deadline_timer m_deadlineTimerForTimeManagerOfCancelSegments;
+    /// Cancellation segment retransmission timer manager
     LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t> m_timeManagerOfCancelSegments;
-
+    
+    /// Housekeeping timer, runs on an interval for executing periodic checks on the current state of the engine
     boost::asio::deadline_timer m_housekeepingTimer;
+    /// Token rate limiter
     TokenRateLimiter m_tokenRateLimiter;
+    /// Token refresh timer
     boost::asio::deadline_timer m_tokenRefreshTimer;
+    /// Rate limiting UDP send rate in bits per second, if set to 0 the engine will send UDP packets as fast as the operating system will allow
     uint64_t m_maxSendRateBitsPerSecOrZeroToDisable;
+    /// Whether the token refresh timer is currently active
     bool m_tokenRefreshTimerIsRunning;
+    /// Time point, used by the token refresh timer to calculate delta time
     boost::posix_time::ptime m_lastTimeTokensWereRefreshed;
+    /// Thread that invokes m_ioServiceLtpEngine.run() (if using dedicated I/O thread)
     std::unique_ptr<boost::thread> m_ioServiceLtpEngineThreadPtr;
 
     //session re-creation prevention
+    /// Session recreation preventers, mapped by session originator engine ID
     std::map<uint64_t, LtpSessionRecreationPreventer> m_mapSessionOriginatorEngineIdToLtpSessionRecreationPreventer;
 
     //memory in files
+    /// Disk memory manager
     std::unique_ptr<MemoryInFiles> m_memoryInFilesPtr;
+    /// Memory block IDs pending deletion queue, manages lifetime of transmission session memory blocks
     std::queue<uint64_t> m_memoryBlockIdsPendingDeletionQueue;
+    /// Pending successful bundle send callback context data queue, feeds invocations of m_onSuccessfulBundleSendCallback
     std::queue<std::vector<uint8_t> > m_userDataPendingSuccessfulBundleSendCallbackQueue;
 
 
     //reference structs common to all sessions
+    /// Session sender common data
     LtpSessionSender::LtpSessionSenderCommonData m_ltpSessionSenderCommonData;
+    /// Session receiver common data
     LtpSessionReceiver::LtpSessionReceiverCommonData m_ltpSessionReceiverCommonData;
 
 public:
     //stats
 
     //LtpEngine
+    /// ...
     uint64_t m_countAsyncSendsLimitedByRate;
+    /// Number of packets pending further processing
     uint64_t m_countPacketsWithOngoingOperations;
+    /// Total number of packets fully processed
     uint64_t m_countPacketsThatCompletedOngoingOperations;
+    /// Total number of times a transmission request was written to disk prior to beginning transmission
     uint64_t m_numEventsTransmissionRequestDiskWritesTooSlow;
 
     //session sender stats (references to variables within m_ltpSessionSenderCommonData)
+    /// Total number of checkpoint retransmission timer expiry callback invocations
     uint64_t & m_numCheckpointTimerExpiredCallbacksRef;
+    /// Total number of discretionary checkpoints reported received
     uint64_t & m_numDiscretionaryCheckpointsNotResentRef;
+    /// Total number of reports deleted after claiming reception of their entire scope
     uint64_t & m_numDeletedFullyClaimedPendingReportsRef;
 
     //session receiver stats
+    /// Total number of report segment timer expiry callback invocations
     uint64_t & m_numReportSegmentTimerExpiredCallbacksRef;
+    /// Total number of report segments unable to be issued
     uint64_t & m_numReportSegmentsUnableToBeIssuedRef;
+    /// Total number of reports too large needing-fragmented (when report claims > m_maxReceptionClaims)
     uint64_t & m_numReportSegmentsTooLargeAndNeedingSplitRef;
+    /// Total number of report segments produced from too large needing-fragmented reports
     uint64_t & m_numReportSegmentsCreatedViaSplitRef;
+    /// Total number of gaps filled by out-of-order data segments
     uint64_t & m_numGapsFilledByOutOfOrderDataSegmentsRef;
+    /// Total number of whole primary report segments sent (only reports when no gaps)
     uint64_t & m_numDelayedFullyClaimedPrimaryReportSegmentsSentRef;
+    /// Total number of whole secondary report segments sent (only reports when no gaps)
     uint64_t & m_numDelayedFullyClaimedSecondaryReportSegmentsSentRef;
+    /// Total number of out-of-order partial primary report segments
     uint64_t & m_numDelayedPartiallyClaimedPrimaryReportSegmentsSentRef;
+    /// Total number of out-of-order partial secondary report segments
     uint64_t & m_numDelayedPartiallyClaimedSecondaryReportSegmentsSentRef;
 };
 

--- a/common/ltp/include/LtpRandomNumberGenerator.h
+++ b/common/ltp/include/LtpRandomNumberGenerator.h
@@ -31,24 +31,131 @@
 
 class LTP_LIB_EXPORT LtpRandomNumberGenerator {
 public:
+    /// Start birthday paradox prevention value from 1.
     LtpRandomNumberGenerator();
+    
+    /** Generate a hardware-generated random 64-bit session number.
+     *
+     * - bits 63..56 (8 bits): Engine index.
+     * - bit  55     (1 bit): Set to 0 to leave room for incrementing without rolling into the engine index.
+     * - bits 54..16 (39 bits): Random part.
+     * - bits 15..0  (16 bits): Birthday paradox prevention part, stays in range [1, std::numeric_limits<std::uint16_t>::max()].
+     * @param additionalRandomness The final random component to XOR.
+     * @return The random 64-bit session number.
+     */
     uint64_t GetRandomSession64(const uint64_t additionalRandomness = 0);
+    
+    /** Generate a random 64-bit session number using given random device.
+     *
+     * Calls LtpRandomNumberGenerator::GetRandomSession64(uint64_t) with the final random component supplied by randomDevice.
+     * @param randomDevice The random device to use.
+     * @return The random 64-bit session number.
+     */
     uint64_t GetRandomSession64(boost::random_device & randomDevice);
+    
+    /** Get 64-bit ping session number.
+     *
+     * - bits 63..56 (8 bits): Engine index.
+     * - bits 55..0  (56 bits): Set to 0xffffff for reserved number denoting ping.
+     * @return The 64-bit ping session number.
+     */
     uint64_t GetPingSession64() const;
+    
+    /** Generate a hardware-generated random 64-bit serial number.
+     *
+     * - bit 63      (1 bit): Set to 0 to leave room for incrementing without rolling back around to zero.
+     * - bits 62..16 (47 bits): Random part.
+     * - bits 15..0  (16 bits): Set to 1 for incrementing ltp serial numbers by 1 (never want a serial number to be 0).
+     * @param additionalRandomness The final random component to XOR.
+     * @return The random 64-bit serial number.
+     */
     uint64_t GetRandomSerialNumber64(const uint64_t additionalRandomness = 0) const;
+    
+    /** Generate a random 64-bit serial number using given random device.
+     *
+     * Calls LtpRandomNumberGenerator::GetRandomSerialNumber64(uint64_t) with the final random component supplied by randomDevice.
+     * @param randomDevice The random device to use.
+     * @return The random 64-bit serial number.
+     */
     uint64_t GetRandomSerialNumber64(boost::random_device & randomDevice) const;
+    
+    /** Generate a hardware-generated random 32-bit session number.
+     *
+     * - bits 31..24 (8 bits): Engine index.
+     * - bit 23      (1 bit): Set to 0 to leave room for incrementing without rolling into the engine index.
+     * - bits 22..16 (7 bits): Random part.
+     * - bits 15..0  (16 bits): Birthday paradox prevention part, stays in range [1, std::numeric_limits<std::uint16_t>::max()].
+     * @param additionalRandomness32Bit The final random component to XOR.
+     * @return The random 32-bit session number.
+     */
     uint32_t GetRandomSession32(const uint32_t additionalRandomness32Bit = 0);
+    
+    /** Generate a random 32-bit session number using given random device.
+     *
+     * Calls LtpRandomNumberGenerator::GetRandomSession32(uint32_t) with the final random component supplied by randomDevice.
+     * @param randomDevice The random device to use.
+     * @return The random 32-bit session number.
+     */
     uint32_t GetRandomSession32(boost::random_device & randomDevice);
+    
+    /** Get 32-bit ping session number.
+     *
+     * - bits 31..24 (8 bits): Engine index.
+     * - bits 23..0  (24 bits): Set to 0xffffff for reserved number denoting ping.
+     * @return The 32-bit ping session number.
+     */
     uint32_t GetPingSession32() const;
+    
+    /** Generate a hardware-generated random 32-bit serial number.
+     *
+     * - bit 31 (1 bit): Set to 0 to leave room for incrementing without rolling back around to zero.
+     * - bits 30..16 (15 bits): Random part.
+     * - bits 15..0 (16 bits): Set to 1 for incrementing ltp serial numbers by 1 (never want a serial number to be 0).
+     * @param additionalRandomness32Bit The final random component to XOR.
+     * @return The random 32-bit serial number.
+     */
     uint32_t GetRandomSerialNumber32(const uint32_t additionalRandomness32Bit = 0) const;
+    
+    /** Generate a random 32-bit serial number using given random device.
+     *
+     * Calls LtpRandomNumberGenerator::GetRandomSerialNumber32(uint32_t) with the final random component supplied by randomDevice.
+     * @param randomDevice The random device to use.
+     * @return The random 32-bit serial number.
+     */
     uint32_t GetRandomSerialNumber32(boost::random_device & randomDevice) const;
-    void SetEngineIndex(const uint8_t engineIndex); //must be between 1 and 255 inclusive
+    
+    /** Set the engine index.
+     *
+     * @param engineIndex The engine index to set, must be in range [1, 255].
+     */
+    void SetEngineIndex(const uint8_t engineIndex);
+    
+    /** Get the engine index.
+     *
+     * @return The engine index.
+     */
     uint8_t GetEngineIndex() const;
+    
+    /** Parse the engine index part of a random session number.
+     *
+     * Assumes the number engine index resides in the top 8 bits, typically generated by LtpRandomNumberGenerator::GetRandomSession64() or the 32-bit variant.
+     * @param randomSessionNumber The random session number to parse.
+     * @return The engine index.
+     */
     static uint8_t GetEngineIndexFromRandomSessionNumber(uint64_t randomSessionNumber);
+    
+    /** Query whether the given session number denotes a ping session.
+     *
+     * @param sessionNumber The session number to check.
+     * @param is32Bit Whether the session number is 32-bit.
+     * @return Whether the given session number denotes a ping session.
+     */
     static bool IsPingSession(const uint64_t sessionNumber, const bool is32Bit);
 private:
+    /// Circular birthday paradox prevention value, stays in range [1, std::numeric_limits<std::uint16_t>::max()]
     uint16_t m_birthdayParadoxPreventer_incrementalPart_U16;
-    uint8_t m_engineIndex; //to encode into the upper portion of a session number
+    /// Engine index, encoded into the upper portion of a session number
+    uint8_t m_engineIndex;
 };
 
 #endif // LTP_RANDOM_NUMBER_GENERATOR_H

--- a/common/ltp/include/LtpSessionReceiver.h
+++ b/common/ltp/include/LtpSessionReceiver.h
@@ -33,28 +33,92 @@
 #include "LtpClientServiceDataToSend.h"
 #include <boost/core/noncopyable.hpp>
 
+/**
+ * @typedef NotifyEngineThatThisReceiverNeedsDeletedCallback_t Type of callback to be invoked when this receiver should be queued for deletion.
+ */
 typedef boost::function<void(const Ltp::session_id_t & sessionId, bool wasCancelled, CANCEL_SEGMENT_REASON_CODES reasonCode)> NotifyEngineThatThisReceiverNeedsDeletedCallback_t;
 
+/**
+ * @typedef NotifyEngineThatThisReceiversTimersHasProducibleDataFunction_t Type of callback to be invoked when this receiver has data to send.
+ */
 typedef boost::function<void(const Ltp::session_id_t & sessionId)> NotifyEngineThatThisReceiversTimersHasProducibleDataFunction_t;
 
+/**
+ * @typedef NotifyEngineThatThisReceiverCompletedDeferredOperationFunction_t Type of callback to be invoked when this receiver has completed a deferred disk operation.
+ */
 typedef boost::function<void()> NotifyEngineThatThisReceiverCompletedDeferredOperationFunction_t;
 
 class LtpSessionReceiver : private boost::noncopyable {
 private:
     LtpSessionReceiver() = delete;
 
+    /** Generate and queue a report for transmission.
+     *
+     * Calls LtpFragmentSet::PopulateReportSegment() to populate a single report segment from the currently received data fragments.
+     * If the reception claims exceed the maximum number of reception claims per segment, calls LtpFragmentSet::SplitReportSegment() to split into
+     * multiple smaller report segments.
+     * For each resulting report segment, attaches an increasing report serial number, queues for transmission and calls m_notifyEngineThatThisReceiversTimersHasProducibleDataFunctionRef()
+     * to notify the associated LtpEngine that there is data to send.
+     * @param checkpointSerialNumber The associated checkpoint serial number.
+     * @param lowerBound The lower bound.
+     * @param upperBound The upper bound.
+     * @param checkpointIsResponseToReportSegment Whether this is a secondary reception report (if False, is primary).
+     */
     LTP_LIB_NO_EXPORT void HandleGenerateAndSendReportSegment(const uint64_t checkpointSerialNumber,
         const uint64_t lowerBound, const uint64_t upperBound, const bool checkpointIsResponseToReportSegment);
+    
+    /** Handle deferred disk write completion.
+     *
+     * Decrements the number of active disk I/O operations.
+     * If NO disk I/O operations are currently in progress AND we have fully received the red part data, queues a deferred disk read to read back the
+     * red part into m_dataReceivedRed (in-memory) with LtpSessionReceiver::OnRedDataRecoveredFromDisk() as a completion handler.
+     * If the deferred read operation is queued successfully, increments the number of active disk I/O operations.
+     * Calls m_notifyEngineThatThisReceiverCompletedDeferredOperationFunctionRef() to notify the associated LtpEngine that a deferred disk operation
+     * has been completed.
+     * @param clientServiceDataReceivedSharedPtr The client service data.
+     * @param isEndOfBlock Whether the data contain the EOB segment.
+     * @post The number of active disk I/O operations is modified (see above for details).
+     */
     LTP_LIB_NO_EXPORT void OnDataSegmentWrittenToDisk(std::shared_ptr<std::vector<uint8_t> >& clientServiceDataReceivedSharedPtr, bool isEndOfBlock);
+    
+    /** Handle deferred red part read completion.
+     *
+     * Decrements the number of active disk I/O operations.
+     * Initiates a deferred memory block deletion for our memory block.
+     * If the red part reception callback is set, calls m_redPartReceptionCallbackRef() to invoke the red part reception callback.
+     * Clears the in-memory red data store.
+     * @param success Whether the read operation was successful.
+     * @param isEndOfBlock Whether the data contain the EOB segment.
+     * @post The number of active disk I/O operations is decremented.
+     */
     LTP_LIB_NO_EXPORT void OnRedDataRecoveredFromDisk(bool success, bool isEndOfBlock);
 public:
-    //these two are public now because they are invoked by LtpEngine (eliminates need for each session to have its own expensive boost::function) 
+    /** Handle pending checkpoint delayed report transmission timer expiry.
+     *
+     * Calls LtpSessionReceiver::HandleGenerateAndSendReportSegment() to generate and queue a report for transmission.
+     * Removes the checkpoint from the pending checkpoints for delayed report transmission.
+     * @param checkpointSerialNumberPlusSessionNumber The associated checkpoint serial number.
+     * @param userData The pending checkpoint delayed report transmission timer context data.
+     */
     LTP_LIB_EXPORT void LtpDelaySendReportSegmentTimerExpiredCallback(const Ltp::session_id_t& checkpointSerialNumberPlusSessionNumber, std::vector<uint8_t>& userData);
+    
+    //these two are public now because they are invoked by LtpEngine (eliminates need for each session to have its own expensive boost::function)
+    /** Handle report retransmission timer expiry.
+     *
+     * Removes the report from the reports with active retransmission timers.
+     * If the transmission retry count is within the report retransmission limit, queues the report back for transmission, then calls m_notifyEngineThatThisReceiversTimersHasProducibleDataFunctionRef()
+     * to notify the associated LtpEngine that there is data to send.
+     * Else, If not already marked, marks the receiver for deferred deletion then calls m_notifyEngineThatThisReceiverNeedsDeletedCallbackRef()
+     * with a cancel code of RLEXC to notify the associated LtpEngine for receiver deletion.
+     * @param reportSerialNumberPlusSessionNumber The report serial number.
+     * @param userData The report retransmission timer context data.
+     */
     LTP_LIB_EXPORT void LtpReportSegmentTimerExpiredCallback(const Ltp::session_id_t& reportSerialNumberPlusSessionNumber, std::vector<uint8_t>& userData);
 
-    //The LtpEngine shall have one copy of this struct and pass it's reference to each LtpSessionReceiver
+    /// Receiver common data, referenced across all receivers associated with the same LtpEngine
     struct LtpSessionReceiverCommonData : private boost::noncopyable {
         LtpSessionReceiverCommonData() = delete;
+        /// Start all stat counters from 0
         LTP_LIB_EXPORT LtpSessionReceiverCommonData(
             const uint64_t clientServiceId,
             uint64_t maxReceptionClaims,
@@ -72,95 +136,258 @@ public:
             const GreenPartSegmentArrivalCallback_t& greenPartSegmentArrivalCallbackRef,
             std::unique_ptr<MemoryInFiles>& memoryInFilesPtrRef);
 
+        /// Local client service ID
         const uint64_t m_clientServiceId;
+        /// Maximum number of reception claims per report segment
         uint64_t m_maxReceptionClaims;
+        /// Estimated maximum number of bytes to reverse space for (both in-memory and for disk storage).
+        /// This is a soft cap to lessen instances of reallocation, the actual space will be expanded if needed.
         uint64_t m_estimatedBytesToReceive;
+        /// Maximum number of red data allowed in bytes per red data part
         uint64_t m_maxRedRxBytes;
+        /// Maximum retries allowed per report
         uint32_t& m_maxRetriesPerSerialNumberRef;
 
+        /// Report retransmission timer manager, timer mapped by session ID, hashed by session ID
         LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t>& m_timeManagerOfReportSerialNumbersRef;
+        /// Report retransmission timer expiry callback
         const LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t>::LtpTimerExpiredCallback_t& m_rsnTimerExpiredCallbackRef;
+        /// Pending checkpoint delayed report transmission timer manager, timer mapped by session ID, hashed by session ID
         LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t>& m_timeManagerOfSendingDelayedReceptionReportsRef;
+        /// Pending checkpoint delayed report transmission timer expiry callback
         const LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t>::LtpTimerExpiredCallback_t& m_delayedReceptionReportTimerExpiredCallbackRef;
 
+        /// LtpEngine this receiver should be queued for deletion notice function
         const NotifyEngineThatThisReceiverNeedsDeletedCallback_t& m_notifyEngineThatThisReceiverNeedsDeletedCallbackRef;
+        /// LtpEngine this receiver has data to send notice function
         const NotifyEngineThatThisReceiversTimersHasProducibleDataFunction_t& m_notifyEngineThatThisReceiversTimersHasProducibleDataFunctionRef;
+        /// LtpEngine this receiver has completed a deferred disk operation notice function
         const NotifyEngineThatThisReceiverCompletedDeferredOperationFunction_t& m_notifyEngineThatThisReceiverCompletedDeferredOperationFunctionRef;
+        /// Red data part reception callback, invoked only on full red data part reception
         const RedPartReceptionCallback_t& m_redPartReceptionCallbackRef;
+        /// Green data segment reception callback, invoked for any partial segment
         const GreenPartSegmentArrivalCallback_t& m_greenPartSegmentArrivalCallbackRef;
+        /// Disk memory manager
         std::unique_ptr<MemoryInFiles>& m_memoryInFilesPtrRef;
 
         //session receiver stats
+        /// Total number of report segment timer expiry callback invocations
         uint64_t m_numReportSegmentTimerExpiredCallbacks;
+        /// Total number of report segments unable to be issued
         uint64_t m_numReportSegmentsUnableToBeIssued;
+        /// Total number of reports too large needing-fragmented (when report claims > m_maxReceptionClaims)
         uint64_t m_numReportSegmentsTooLargeAndNeedingSplit;
+        /// Total number of report segments produced from too large needing-fragmented reports
         uint64_t m_numReportSegmentsCreatedViaSplit;
+        /// Total number of gaps filled by out-of-order data segments
         uint64_t m_numGapsFilledByOutOfOrderDataSegments;
+        /// Total number of whole primary report segments sent (only reports when no gaps)
         uint64_t m_numDelayedFullyClaimedPrimaryReportSegmentsSent;
+        /// Total number of whole secondary report segments sent (only reports when no gaps)
         uint64_t m_numDelayedFullyClaimedSecondaryReportSegmentsSent;
+        /// Total number of out-of-order partial primary report segments
         uint64_t m_numDelayedPartiallyClaimedPrimaryReportSegmentsSent;
+        /// Total number of out-of-order partial secondary report segments
         uint64_t m_numDelayedPartiallyClaimedSecondaryReportSegmentsSent;
     };
     
     
+    /**
+     * Start all stat counters from 0 and initialize flags.
+     * Set m_lengthOfRedPart and m_lowestGreenOffsetReceived to UINT16_MAX.
+     * Reserve m_estimatedBytesToReceive bytes of space on disk (if using the disk for intermediate storage) or in-memory as a fallback.
+     */
     LTP_LIB_EXPORT LtpSessionReceiver(uint64_t randomNextReportSegmentReportSerialNumber,
         const Ltp::session_id_t & sessionId,
         LtpSessionReceiverCommonData& ltpSessionReceiverCommonDataRef);
 
+    /// Clean up active report and pending checkpoint delayed report transmission timers from the shared timer manager
     LTP_LIB_EXPORT ~LtpSessionReceiver();
+    
+    /** Load next report segment to send.
+     *
+     * If the reports needing-transmitted is empty, returns immediately with a value of False.
+     * Else, the first queued segment is popped from the queue and loaded into the send operation data context, then a report retransmission timer
+     * is attempted to be started.
+     * @param udpSendPacketInfo The send operation context data to modify.
+     * @return True if there is a segment to send and it could be loaded successfully (and thus the send operation context data are modified), or False otherwise.
+     * @post If returns True, the argument to udpSendPacketInfo is modified accordingly (see above for details).
+     */
     LTP_LIB_EXPORT bool NextDataToSend(UdpSendPacketInfo& udpSendPacketInfo);
     
-    LTP_LIB_EXPORT std::size_t GetNumActiveTimers() const; //stagnant rx session detection in ltp engine with periodic housekeeping timer
+    /** Get number of currently active timers.
+     *.
+     * Used by LtpEngine housekeeping timer to detect idle open sessions.
+     * @return The number of currently active timers (report retransmission timers PLUS pending checkpoint delayed report transmission timers).
+     */
+    LTP_LIB_EXPORT std::size_t GetNumActiveTimers() const;
+    
+    /** Whether it is safe to delete this receiver.
+     *
+     * A receiver is considered safe for deletion if there are NO disk I/O operations in progress.
+     * @return True if it is safe to delete this receiver, or False otherwise.
+     */
     LTP_LIB_EXPORT bool IsSafeToDelete() const noexcept;
+    
+    /** Handle report acknowledgment segment reception.
+     *
+     * Updates the last segment received timestamp to refresh the idleness status for this receiver.
+     * Deletes the report retransmission timer.
+     * 1. If the reports needing-transmitted queue is empty AND the there are no report retransmission timers active:
+     *   A. If the red or green EOB segment is received AND the red data part reception callback has already been invoked.
+     *     If not already marked, marks the receiver for deferred deletion then calls m_notifyEngineThatThisReceiverNeedsDeletedCallbackRef()
+     *     with a cancel code of RESERVED to notify the associated LtpEngine for receiver deletion.
+     *   B. If the green EOB segment is lost:
+     *     ??? (Unspecified)
+     * @param reportSerialNumberBeingAcknowledged The associated report serial number.
+     * @param headerExtensions The LTP header extensions.
+     * @param trailerExtensions The LTP trailer extensions.
+     */
     LTP_LIB_EXPORT void ReportAcknowledgementSegmentReceivedCallback(uint64_t reportSerialNumberBeingAcknowledged,
         Ltp::ltp_extensions_t & headerExtensions, Ltp::ltp_extensions_t & trailerExtensions);
 
-    //return true if operation is ongoing (possibly due to disk writes),
-    // false if operation is done (and udp packet circular buffer can reduce its size)
+    /** Handle data segment reception.
+     *
+     * Updates the last segment received timestamp to refresh the idleness status for this receiver.
+     * 1. If the segment is EOB (either red of green):
+     *   Marks reception of an EOB segment.
+     * 2. If this is a red segment:
+     *   Advances the currently received red data length appropriately.
+     *   A. If this is a miscolored segment (m_currentRedLength > m_lowestGreenOffsetReceived):
+     *     If not already marked, marks the receiver for deferred deletion then calls m_notifyEngineThatThisReceiverNeedsDeletedCallbackRef()
+     *     with a cancel code of MISCOLORED to notify the associated LtpEngine for receiver deletion.
+     *   B. If the red data part reception callback has already been invoked:
+     *     No further processing is required.
+     *   C. If the currently received red data length exceeds the maximum red part length limit:
+     *     If not already marked, marks the receiver for deferred deletion then calls m_notifyEngineThatThisReceiverNeedsDeletedCallbackRef()
+     *     with a cancel code of SYSTEM_CANCELLED to notify the associated LtpEngine for receiver deletion.
+     *   D. If this data segment contains data not previously received (still pending arrival):
+     *     a. If using the disk for intermediate storage:
+     *       Initiates a deferred disk write operation with LtpSessionReceiver::OnDataSegmentWrittenToDisk() as a completion handler,
+     *       resizing our memory block appropriately, the client service data are MOVED for this deferred write.
+     *       If the disk I/O operation is queued successfully, the number of active disk I/O operations is incremented.
+     *       this branch eventually leads to this function returning True to indicate a pending operation in progress (the deferred disk write).
+     *     b. If storing the data in-memory:
+     *       The resizing takes place in our in-memory data store but the client service data are COPIED and NOT MOVED.
+     *     c. If this data segment JUST NOW filled all reception gaps for a pending checkpoint for delayed report transmission:
+     *       Calls LtpSessionReceiver::HandleGenerateAndSendReportSegment() to generate and queue for transmission the appropriate report, then
+     *       the pending checkpoint delayed report transmission timer is deleted.
+     *   E. If this is a red checkpoint segment:
+     *     If the checkpoint serial number OR the associated report serial number are NULL, this segment is invalid no further processing is required.
+     *     If this is a redundant segment, no further processing is required.
+     *     Sets the lower bound of the associated report (and any subsequent reports if necessary) appropriately depending on the type of
+     *     the checkpoint (primary or secondary).
+     *     If this is a discretionary checkpoint for which a report should NOT be issued, no further processing is required.
+     *     Else, (if this is a discretionary checkpoint for which a report should be issued):
+     *     a. [UNIT TESTING]: If we are NOT handling possibly out-of-order reception of data segments:
+     *       Calls LtpSessionReceiver::HandleGenerateAndSendReportSegment() to generate and queue for transmission the appropriate report.
+     *     b. If we are handling possibly out-of-order reception of data segments:
+     *       The segment is added to the pending checkpoint for delayed report transmission and the pending checkpoint delayed report transmission
+     *       timer is attempted to be started.
+     *   F. If this is a red segment that JUST NOW filled all reception gaps for the entire red part and the red part reception callback
+     *   has NOT already been invoked:
+     *     If this is NOT a checkpoint AND a report has NOT already been issued (by branch 2.D.c), calls LtpSessionReceiver::HandleGenerateAndSendReportSegment()
+     *     to generate and queue for transmission a report covering the entire range of the red data part.
+     *     Marks the red part reception callback as completed.
+     *     If using the disk for intermediate storage, does nothing and lets the callback be naturally deferred to the asynchronous disk read handler.
+     *     Else, calls m_redPartReceptionCallbackRef() to invoke the red part reception callback with data loaded from the in-memory data store.
+     * 3. If this is a green segment:
+     *   Advances the currently received lowest green offset appropriately.
+     *   A. If this is a miscolored segment (m_currentRedLength > m_lowestGreenOffsetReceived):
+     *     If not already marked, marks the receiver for deferred deletion then calls m_notifyEngineThatThisReceiverNeedsDeletedCallbackRef()
+     *     with a cancel code of MISCOLORED to notify the associated LtpEngine for receiver deletion.
+     *   B. If the green data reception callback is set:
+     *     Calls m_greenPartSegmentArrivalCallbackRef() to invoke the green data reception callback for this data segment.
+     *   C. If this is a green EOB segment:
+     *     If this is a fully green session OR the red part reception callback has already been invoked (which indicates full reception
+     *     of the red part), if not already marked, marks the receiver for deferred deletion then calls m_notifyEngineThatThisReceiverNeedsDeletedCallbackRef()
+     *     with a cancel code of RESERVED to notify the associated LtpEngine for receiver deletion.
+     * @param segmentTypeFlags The segment type flags.
+     * @param clientServiceDataVec The client service data.
+     * @param dataSegmentMetadata The data segment metadata.
+     * @param headerExtensions The LTP header extensions.
+     * @param trailerExtensions The LTP trailer extensions.
+     * @return True if the operation is still in progress on function exit (currently only on asynchronous disk writes), or False otherwise.
+     * @post The argument to clientServiceDataVec MIGHT be left in a moved-from state (see above for details) (branch 2.D.a).
+     * @post The number of active disk I/O operations MIGHT be incremented (see above for details) (branch 2.D.a).
+     * @post If returns False, indicates that the UDP circular index buffer can reduce its size.
+     */
     LTP_LIB_EXPORT bool DataSegmentReceivedCallback(uint8_t segmentTypeFlags,
         std::vector<uint8_t> & clientServiceDataVec, const Ltp::data_segment_metadata_t & dataSegmentMetadata,
         Ltp::ltp_extensions_t & headerExtensions, Ltp::ltp_extensions_t & trailerExtensions);
 private:
+    /// Received data fragments
     std::set<LtpFragmentSet::data_fragment_t> m_receivedDataFragmentsSet;
+    /// Type of map holding report segments, mapped by report serial number
     typedef std::map<uint64_t, Ltp::report_segment_t> report_segments_sent_map_t;
+    /// Report segments sent, mapped by report serial number
     report_segments_sent_map_t m_mapAllReportSegmentsSent;
+    /// Last primary report segment sent iterator
     report_segments_sent_map_t::const_iterator m_itLastPrimaryReportSegmentSent; //std::map<uint64_t, Ltp::report_segment_t> m_mapPrimaryReportSegmentsSent;
     
     //std::set<LtpFragmentSet::data_fragment_t> m_receivedDataFragmentsThatSenderKnowsAboutSet;
+    /// Received checkpoint serial numbers
     std::set<uint64_t> m_checkpointSerialNumbersReceivedSet;
+    /// Type of pair holding retries per report segment sent, (Report segment sent iterator TO number of retries)
     typedef std::pair<report_segments_sent_map_t::const_iterator, uint32_t> it_retrycount_pair_t; //pair<iterator from m_mapAllReportSegmentsSent, retryCount>
+    /// Reports needing-transmitted queue
     ForwardListQueue<it_retrycount_pair_t> m_reportsToSendFlistQueue;
     
+    /// Report serial numbers with active retransmission timers
     std::list<uint64_t> m_reportSerialNumberActiveTimersList;
     
+    /// Report retransmission timer context data
     struct rsntimer_userdata_t {
+        /// Report segment sent iterator
         report_segments_sent_map_t::const_iterator itMapAllReportSegmentsSent;
+        /// Report serial number with active retransmission timer iterator
         std::list<uint64_t>::iterator itReportSerialNumberActiveTimersList;
+        /// Number of retries
         uint32_t retryCount;
     };
 
-    //(rsLowerBound, rsUpperBound) to (checkpointSerialNumberToWhichRsPertains, checkpointIsResponseToReportSegment) map
+    /// Type of pair holding checkpoint type metadata, (checkpoint serial number TO whether this is a secondary checkpoint).
+    /// (checkpointSerialNumberToWhichRsPertains, checkpointIsResponseToReportSegment).
     typedef std::pair<uint64_t, bool> csn_issecondary_pair_t;
+    /// Type of map holding checkpoint type metadata, mapped by data segment bounds (rsLowerBound, rsUpperBound)
     typedef std::map<FragmentSet::data_fragment_no_overlap_allow_abut_t, csn_issecondary_pair_t> rs_pending_map_t;
+    /// Pending checkpoint fragments, mapped by data segment bounds.
+    /// When (m_mapReportSegmentsPendingGeneration.empty()) indicates no active pending checkpoint delayed report transmission timers.
+    /// Used to recalculate gaps from received data fragments for pending checkpoint delayed report generation.
     rs_pending_map_t m_mapReportSegmentsPendingGeneration;
     
+    /// Next report segment serial number
     uint64_t m_nextReportSegmentReportSerialNumber;
+    /// Currently received red data stored in-memory, if using the disk for intermediate storage see below how to handle loading and accessing data
     padded_vector_uint8_t m_dataReceivedRed;
+    /// Allocation size in bytes of our memory block, if 0 the block is invalid, handled by MemoryInFiles::Resize()
     uint64_t m_memoryBlockIdReservedSize; //since its resize rounds up
+    /// Our session ID
     const Ltp::session_id_t M_SESSION_ID;
     uint64_t m_lengthOfRedPart;
+    /// Currently received lowest green data offset, when (m_currentRedLength > m_lowestGreenOffsetReceived) we have received a miscolored segment
     uint64_t m_lowestGreenOffsetReceived;
-    uint64_t m_currentRedLength; //cannot just use variable in m_dataReceivedRed.size() because may be using disk instead
+    /// Currently received red data length in bytes, when (m_currentRedLength > m_lowestGreenOffsetReceived) we have received a miscolored segment.
+    /// Cannot just use variable in (m_dataReceivedRed.size()) because may be using disk instead.
+    uint64_t m_currentRedLength;
+    /// Receiver common data reference, the data shared by all receivers of the associated LtpEngine
     LtpSessionReceiverCommonData& m_ltpSessionReceiverCommonDataRef;
+    /// Our memory block ID, if using the disk for intermediate storage the ID MUST be non-zero, data are loaded in-memory before invocation of completion callbacks
     uint64_t m_memoryBlockId;
 public:
-    boost::posix_time::ptime m_lastSegmentReceivedTimestamp; //stagnant rx session detection in ltp engine with periodic housekeeping timer
+    /// Last segment (either data or report acknowledgment) received timestamp, used by LtpEngine housekeeping timer to detect idle open sessions
+    boost::posix_time::ptime m_lastSegmentReceivedTimestamp;
 private:
+    /// Number of system read or write I/O operations currently in progress, for graceful cleanup wait until there are no active disk I/O operations before deleting this receiver
     uint32_t m_numActiveAsyncDiskOperations;
+    /// Whether the red part fully received callback has been called, indicates receive completion for the red part data of this session
     bool m_didRedPartReceptionCallback;
+    /// Whether deferred deletion of this receiver has been requested (typically on session completed), used to notify the associated LtpEngine
     bool m_didNotifyForDeletion;
+    /// Whether we have received an EOB segment (either red or green)
     bool m_receivedEobFromGreenOrRed;
 public:
+    /// Whether the cancellation callback has been invoked, used to prevent against multiple executions of the session completion procedure
     bool m_calledCancelledCallback;
 };
 

--- a/common/ltp/include/LtpSessionRecreationPreventer.h
+++ b/common/ltp/include/LtpSessionRecreationPreventer.h
@@ -34,17 +34,41 @@ private:
     LtpSessionRecreationPreventer() = delete;
 public:
     
+    /**
+     * Preallocate M_NUM_RECEIVED_SESSION_NUMBERS_TO_REMEMBER number of elements for quarantine set and queue.
+     * Start circular write index from 0.
+     * @param numReceivedSessionsToRemember The number of session numbers to remember.
+     */
     LTP_LIB_EXPORT LtpSessionRecreationPreventer(const uint64_t numReceivedSessionsToRemember);
+    
+    /// Default destructor.
     LTP_LIB_EXPORT ~LtpSessionRecreationPreventer();
     
+    /** Add session number to quarantine.
+     *
+     * @param newSessionNumber The session number to add.
+     * @return True if the session number was added successfully, or False otherwise.
+     * @post If returning True and max capacity would have been exceeded, the session number is added to quarantine and the oldest session number is evicted.
+     */
     LTP_LIB_EXPORT bool AddSession(const uint64_t newSessionNumber);
+    
+    /** Query whether quarantine contains session number.
+     *
+     * @param newSessionNumber The session number to query.
+     * @return True if quarantine contains session number, or False otherwise.
+     */
     LTP_LIB_EXPORT bool ContainsSession(const uint64_t newSessionNumber) const;
 
 private:
+    /// Maximum number of session numbers to remember
     const uint64_t M_NUM_RECEIVED_SESSION_NUMBERS_TO_REMEMBER;
+    /// Session number quarantine set, for fast lookup
     std::unordered_set<uint64_t> m_previouslyReceivedSessionNumbersUnorderedSet;
+    /// Session number quarantine queue, evicts oldest -> newest on push when full
     std::vector<uint64_t> m_previouslyReceivedSessionNumbersQueueVector;
+    /// Whether m_previouslyReceivedSessionNumbersQueueVector is currently full
     bool m_queueIsFull;
+    /// Circular write index, used by m_previouslyReceivedSessionNumbersQueueVector
     uint64_t m_nextQueueIndex;
 };
 

--- a/common/ltp/include/LtpSessionSender.h
+++ b/common/ltp/include/LtpSessionSender.h
@@ -33,11 +33,14 @@
 #include "LtpClientServiceDataToSend.h"
 #include <boost/core/noncopyable.hpp>
 
-
-
-
+/**
+ * @typedef NotifyEngineThatThisSenderNeedsDeletedCallback_t Type of callback to be invoked when this sender should be queued for deletion.
+ */
 typedef boost::function<void(const Ltp::session_id_t & sessionId, bool wasCancelled, CANCEL_SEGMENT_REASON_CODES reasonCode, std::shared_ptr<LtpTransmissionRequestUserData> & userDataPtr)> NotifyEngineThatThisSenderNeedsDeletedCallback_t;
 
+/**
+ * @typedef NotifyEngineThatThisSenderHasProducibleDataFunction_t Type of callback to be invoked when this sender has data to send.
+ */
 typedef boost::function<void(const uint64_t sessionNumber)> NotifyEngineThatThisSenderHasProducibleDataFunction_t;
 
 class LtpSessionSender : private boost::noncopyable {
@@ -45,9 +48,10 @@ private:
     LtpSessionSender() = delete;
 public:
 
-    //The LtpEngine shall have one copy of this struct and pass it's reference to each LtpSessionSender
+    /// Sender common data, referenced across all senders associated with the same LtpEngine
     struct LtpSessionSenderCommonData : private boost::noncopyable {
         LtpSessionSenderCommonData() = delete;
+        /// Start all stat counters from 0
         LTP_LIB_EXPORT LtpSessionSenderCommonData(
             uint64_t mtuClientServiceData,
             uint64_t checkpointEveryNthDataPacket,
@@ -60,94 +64,268 @@ public:
             const NotifyEngineThatThisSenderHasProducibleDataFunction_t& notifyEngineThatThisSenderHasProducibleDataFunctionRef,
             const InitialTransmissionCompletedCallback_t& initialTransmissionCompletedCallbackRef);
 
+        /// The max size of the data portion (excluding LTP headers and UDP headers and IP headers) of a red data segment
         uint64_t m_mtuClientServiceData;
+        /// Enables accelerated retransmission for an LTP sender by making every Nth UDP packet a checkpoint (0 disables)
         uint64_t m_checkpointEveryNthDataPacket;
+        /// The max number of retries/resends of a single LTP packet with a serial number before the session is terminated
         uint32_t & m_maxRetriesPerSerialNumberRef;
+        /// Checkpoint retransmission timer manager, timer mapped by session ID, hashed by session ID
         LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t>& m_timeManagerOfCheckpointSerialNumbersRef;
+        /// Checkpoint retransmission timer expiry callback
         const LtpTimerManager<Ltp::session_id_t, Ltp::hash_session_id_t>::LtpTimerExpiredCallback_t& m_csnTimerExpiredCallbackRef;
+        /// Data segment retransmission timer manager, timer mapped by session number, hashed by session number
         LtpTimerManager<uint64_t, std::hash<uint64_t> >& m_timeManagerOfSendingDelayedDataSegmentsRef;
+        /// Data segment retransmission timer expiry callback
         const LtpTimerManager<uint64_t, std::hash<uint64_t> >::LtpTimerExpiredCallback_t& m_delayedDataSegmentsTimerExpiredCallbackRef;
         
+        /// LtpEngine this sender should be queued for deletion notice function
         const NotifyEngineThatThisSenderNeedsDeletedCallback_t& m_notifyEngineThatThisSenderNeedsDeletedCallbackRef;
+        /// LtpEngine this sender has data to send notice function
         const NotifyEngineThatThisSenderHasProducibleDataFunction_t& m_notifyEngineThatThisSenderHasProducibleDataFunctionRef;
+        /// LtpEngine this sender has completed initial data transmission (first pass) notice function
         const InitialTransmissionCompletedCallback_t& m_initialTransmissionCompletedCallbackRef;
 
         //session sender stats
+        /// Total number of checkpoint retransmission timer expiry callback invocations
         uint64_t m_numCheckpointTimerExpiredCallbacks;
+        /// Total number of discretionary checkpoints reported received
         uint64_t m_numDiscretionaryCheckpointsNotResent;
+        /// Total number of reports deleted after claiming reception of their entire scope
         uint64_t m_numDeletedFullyClaimedPendingReports;
     };
+
     
+    /// Clean up active checkpoint and data segment retransmission timers from the shared timer manager
     LTP_LIB_EXPORT ~LtpSessionSender();
+    
+    /**
+     * Start counters from 0 and initialize flags.
+     * @post The arguments to dataToSend and userDataPtrToTake are left in a moved-from state.
+     */
     LTP_LIB_EXPORT LtpSessionSender(uint64_t randomInitialSenderCheckpointSerialNumber, LtpClientServiceDataToSend && dataToSend,
         std::shared_ptr<LtpTransmissionRequestUserData> && userDataPtrToTake, uint64_t lengthOfRedPart,
         const Ltp::session_id_t & sessionId, const uint64_t clientServiceId,
         const uint64_t memoryBlockId, LtpSessionSenderCommonData& ltpSessionSenderCommonDataRef);
+    
+    /** Load next critical data segment to send.
+     *
+     * Critical data priority (in descending order, 1 is highest priority):
+     * 1. Internal operation queue segments (includes report acknowledgment segments):
+     *   If the queue is NOT empty, the first queued segment is popped from the queue and loaded into the send operation data context.
+     * 2. Data fragments needing-retransmitted queue segments:
+     *   If the red data part of this session has already been reported received, clears the data fragment needing-retransmitted queue and returns
+     *   with a value of False.
+     *   Else, if the queue is NOT empty, the first queued segment is popped from the queue and the send operation context data are modified accordingly:
+     *   A. If the segment is a checkpoint:
+     *     A checkpoint retransmission timer is attempted to be started.
+     *   B. If the data need to be read from disk:
+     *     The deferred disk read context data are updated for an eventual deferred read NOT initiated from this function, the data are NOT loaded in-memory.
+     *   C. If the data need to be read from memory:
+     *     The data are loaded from the in-memory client service data to send, then the send operation data context is updated to hold a copy
+     *     of the shared pointer to the in-memory client service data to send, so the data are not deleted before the send operation is completed.
+     * @param udpSendPacketInfo The send operation context data to modify.
+     * @return True if there is a segment to send and it could be loaded successfully (and thus the send operation context data are modified), or False otherwise.
+     * @post If returns True, the argument to udpSendPacketInfo is modified accordingly (see above for details).
+     */
     LTP_LIB_EXPORT bool NextTimeCriticalDataToSend(UdpSendPacketInfo & udpSendPacketInfo);
+    
+    /** Load next first-pass data segment to send.
+     *
+     * If there are no first-pass data left to send, returns immediately with a value of False.
+     * Else, the send operation context data are modified accordingly:
+     * 1. If we are sending red data:
+     *   A. If the segment is a checkpoint (periodic, EORP or EOB):
+     *     The segment checkpoint type is updated appropriately, then a checkpoint retransmission timer is attempted to be started.
+     *   B. If the data need to be read from disk:
+     *     The deferred disk read context data are updated for an eventual deferred read NOT initiated from this function, the data are NOT loaded in-memory.
+     *   C. If the data need to be read from memory:
+     *     The data are loaded from the in-memory client service data to send.
+     *   D. Finally:
+     *     Advances the next first-pass data offset.
+     * 2. If we are sending green data:
+     *   A. If the segment is a checkpoint (EOB):
+     *     The segment checkpoint type is updated appropriately, green data do NOT use checkpoint retransmission timers.
+     *   B. If the data need to be read from disk:
+     *     The deferred disk read context data are updated for an eventual deferred read NOT initiated from this function, the data are NOT loaded in-memory.
+     *   C. If the data need to be read from memory:
+     *     The data are loaded from the in-memory client service data to send.
+     *   D. Finally:
+     *     Advances the next first-pass data offset.
+     * 3. Finally:
+     *   A. If the data were loaded from memory:
+     *     The send operation data context is updated to hold a copy of the shared pointer to the in-memory client service data to send,
+     *     so the data are not deleted before the send operation is completed.
+     *   B. [SYSTEM]: If execution reaches this point:
+     *     Calls m_initialTransmissionCompletedCallbackRef() to notify the associated LtpEngine that initial data transmission (first pass) has been completed.
+     *   C. If this is a fully green send session OR if all the red data have already been reported-received:
+     *     If not already marked, marks the sender for deferred deletion then calls m_notifyEngineThatThisSenderNeedsDeletedCallbackRef()
+     *     with a cancel code of RESERVED to notify the associated LtpEngine for sender deletion.
+     * @param udpSendPacketInfo The send operation context data to modify.
+     * @return True if there is a segment to send and it could be loaded successfully (and thus the send operation context data are modified), or False otherwise.
+     * @post If returns True, the argument to udpSendPacketInfo is modified accordingly (see above for details).
+     */
     LTP_LIB_EXPORT bool NextFirstPassDataToSend(UdpSendPacketInfo& udpSendPacketInfo);
 
     
+    /** Handle report segment reception.
+     *
+     * Appends a report acknowledgment segment with the same serial number as the report segment to the internal operations queue.
+     * Regardless of processing (if any) of the segment, if the sender is not marked for deletion, calls m_notifyEngineThatThisSenderHasProducibleDataFunctionRef()
+     * to notify the associated LtpEngine that there is data to send.
+     * If the report segment is redundant, no processing is required.
+     * Else, processing goes through the following steps:
+     * 1. If the report segment has a non-zero checkpoint serial number.
+     *   The active checkpoint timer associated with the report is deleted.
+     * 2. If scope of the report segment has already been processed by earlier reports:
+     *   No further processing is required.
+     * 3. If this report covers still pending data segments:
+     *   A. If all red data have JUST NOW been reported received by the addition of this report (first time only):
+     *     Set the all red data reported received flag.
+     *   B. If all red and green data have already been sent AND all red data have been reported received:
+     *     If not already marked, marks the sender for deferred deletion then calls m_notifyEngineThatThisSenderNeedsDeletedCallbackRef()
+     *     with a cancel code of RESERVED to notify the associated LtpEngine for sender deletion.
+     *   C. [UNIT TESTING]: If we are NOT handling possibly out-of-order reception of report segments:
+     *     Calls LtpSessionSender::ResendDataFromReport() to begin retransmission for the unaccounted-for needing-retransmitted data fragments
+     *     with only the last fragment marked as a checkpoint.
+     *   C. If we are handling possibly out-of-order reception of report segments:
+     *     If the data segment retransmission timer is NOT currently running AND there are data fragments needing-retransmitted, the data segment
+     *     retransmission timer is attempted to be started.
+     *     If the data segment retransmission timer is currently running AND this report JUST NOW filled all reception claim gaps for the
+     *     data fragments needing-retransmitted, the timer is stopped and the data fragments needing-retransmitted are cleared.
+     * @param reportSegment The report segment.
+     * @param headerExtensions The LTP header extensions.
+     * @param trailerExtensions The LTP trailer extensions.
+     */
     LTP_LIB_EXPORT void ReportSegmentReceivedCallback(const Ltp::report_segment_t & reportSegment,
         Ltp::ltp_extensions_t & headerExtensions, Ltp::ltp_extensions_t & trailerExtensions);
     
-    //these two are public now because they are invoked by LtpEngine (eliminates need for each session to have its own expensive boost::function) 
+    //these two are public now because they are invoked by LtpEngine (eliminates need for each session to have its own expensive boost::function)
+    /** Handle checkpoint retransmission timer expiry.
+     *
+     * Deletes the active checkpoint retransmission timer.
+     * 1. If the transmission retry count is within the checkpoint retransmission limit:
+     *   If this is a discretionary checkpoint, the checkpoint is NOT retransmitted and is thus dropped.
+     *   Else, the checkpoint is queued back for retransmission, the retry count is incremented, then calls m_notifyEngineThatThisSenderHasProducibleDataFunctionRef()
+     *   to notify the associated LtpEngine that there is data to send.
+     * 2. If the checkpoint retransmission limit has been reached:
+     *   If not already marked, marks the sender for deferred deletion then calls m_notifyEngineThatThisSenderNeedsDeletedCallbackRef()
+     *   with a cancel code of RLEXC to notify the associated LtpEngine for sender deletion, also marks this session as failed.
+     * @param checkpointSerialNumberPlusSessionNumber The checkpoint session ID.
+     * @param userData The checkpoint retransmission timer context data.
+     */
     LTP_LIB_EXPORT void LtpCheckpointTimerExpiredCallback(const Ltp::session_id_t& checkpointSerialNumberPlusSessionNumber, std::vector<uint8_t>& userData);
+
+    //these two are public now because they are invoked by LtpEngine (eliminates need for each session to have its own expensive boost::function)
+    /** Handle data segment retransmission timer expiry.
+     *
+     * Calculates the data fragments needing-retransmitted, then on each resulting data fragment calls LtpSessionSender::ResendDataFromReport()
+     * to begin retransmission,
+     * Clears the pending report serial numbers.
+     * If the sender is not marked for deletion, calls m_notifyEngineThatThisSenderHasProducibleDataFunctionRef() to notify the associated LtpEngine
+     * that there is data to send.
+     * @param sessionNumber Our session number.
+     * @param userData The data segment retransmission timer context data.
+     */
     LTP_LIB_EXPORT void LtpDelaySendDataSegmentsTimerExpiredCallback(const uint64_t& sessionNumber, std::vector<uint8_t>& userData);
 
 private:
+    /** Queue for retransmission data fragments needing-retransmitted for the given report.
+     *
+     * Queue each data fragment for retransmission in the data fragments needing-retransmitted queue, setting only the last data fragment
+     * as a checkpoint and setting EORP and EOB appropriately.
+     * @param fragmentsNeedingResent The data fragments needing-retransmitted.
+     * @param reportSerialNumber The report serial number.
+     */
     LTP_LIB_NO_EXPORT void ResendDataFromReport(const std::set<LtpFragmentSet::data_fragment_t>& fragmentsNeedingResent, const uint64_t reportSerialNumber);
     
-
+    /// Checkpoint fragment retransmission context data
     struct resend_fragment_t {
+        /// Default constructor
         resend_fragment_t() {}
+        /// Start number of retries from 1
         resend_fragment_t(uint64_t paramOffset, uint64_t paramLength, uint64_t paramCheckpointSerialNumber, uint64_t paramReportSerialNumber, LTP_DATA_SEGMENT_TYPE_FLAGS paramFlags) :
             offset(paramOffset), length(paramLength), checkpointSerialNumber(paramCheckpointSerialNumber), reportSerialNumber(paramReportSerialNumber), flags(paramFlags), retryCount(1) {}
+        /// Fragment offset
         uint64_t offset;
+        /// Fragment length
         uint64_t length;
+        /// Checkpoint serial number
         uint64_t checkpointSerialNumber;
+        /// Associated report serial number
         uint64_t reportSerialNumber;
+        /// Data segment type
         LTP_DATA_SEGMENT_TYPE_FLAGS flags;
+        /// Number of retries
         uint32_t retryCount;
     };
+    
+    /// Checkpoint retransmission timer context data
     struct csntimer_userdata_t {
+        /// Checkpoint serial number with active retransmission timer iterator
         std::list<uint64_t>::iterator itCheckpointSerialNumberActiveTimersList;
+        /// Checkpoint fragment retransmission context data
         resend_fragment_t resendFragment;
     };
 
+    /// Data fragments reported received
     std::set<LtpFragmentSet::data_fragment_t> m_dataFragmentsAckedByReceiver;
+    /// Internal operations queue, includes report acknowledgment segments
     ForwardListQueue<std::vector<uint8_t> > m_nonDataToSendFlistQueue;
+    /// Data fragments needing-retransmitted queue
     ForwardListQueue<resend_fragment_t> m_resendFragmentsFlistQueue;
+    /// Received report serial numbers
     std::set<uint64_t> m_reportSegmentSerialNumbersReceivedSet;
 
     
+    /// Checkpoint serial numbers with active retransmission timers, a timer stops being active either on reported receive or on RLEXC triggered by checkpoint retransmission limit
     std::list<uint64_t> m_checkpointSerialNumberActiveTimersList;
 
     
-    //(rsLowerBound, rsUpperBound) to (reportSerialNumber) map
+    /// Type of map holding report serial numbers, mapped by report scope bounds (rsLowerBound, rsUpperBound)
     typedef std::map<FragmentSet::data_fragment_unique_overlapping_t, uint64_t> ds_pending_map_t;
+
+    /// Pending report serial numbers, mapped by report scope bounds, when (m_mapRsBoundsToRsnPendingGeneration.empty()) indicates no active data segment retransmission timers
+    /// Used to recalculate gaps in reception claims for data segment retransmission.
     ds_pending_map_t m_mapRsBoundsToRsnPendingGeneration;
+    /// Upper bound of received report with the largest scope span, used to recalculate gaps in reception claims for data segment retransmission
     uint64_t m_largestEndIndexPendingGeneration;
 
+    /// ...
     uint64_t m_receptionClaimIndex;
+    /// Next checkpoint serial number
     uint64_t m_nextCheckpointSerialNumber;
 public:
+    /// Client service data to send (red prefix and green suffix), when (m_dataToSendSharedPtr->data() == NULL) we MUST read the data from disk instead
     std::shared_ptr<LtpClientServiceDataToSend> m_dataToSendSharedPtr;
+    /// Session attached client service data
     std::shared_ptr<LtpTransmissionRequestUserData> m_userDataPtr;
 private:
+    /// Red part data length in bytes
     uint64_t M_LENGTH_OF_RED_PART;
+    /// Next first pass data offset, used for initial transmission, when (m_dataIndexFirstPass >= M_LENGTH_OF_RED_PART) the rest of the data pending initial transmission are all green data
     uint64_t m_dataIndexFirstPass;
+    /// Our session ID
     const Ltp::session_id_t M_SESSION_ID;
+    /// Remote client service ID
     const uint64_t M_CLIENT_SERVICE_ID;
+    /// Periodic checkpoint counter, if using periodic checkpoints for every Nth packet, when the counter reaches zero the next packet MUST be a checkpoint and the counter reset
     uint64_t m_checkpointEveryNthDataPacketCounter;
 public:
+    /// Our memory block ID, if using the disk for intermediate storage the ID MUST be non-zero, the lifetime of the memory block is managed by the associated LtpEngine
     const uint64_t MEMORY_BLOCK_ID;
 private:
+    /// Sender common data reference, the data shared by all senders of the associated LtpEngine
     LtpSessionSenderCommonData& m_ltpSessionSenderCommonDataRef;
+    /// Whether deferred deletion of this sender has been requested (typically on session completed), used to notify the associated LtpEngine
     bool m_didNotifyForDeletion;
+    /// Whether the receiver has received all the red data, if True we can safely delete all the currently stored red data segments
     bool m_allRedDataReceivedByRemote;
 public:
     //stats
+    /// Whether the send session has been completed due to a fatal error, currently only used on RLEXC triggered by checkpoint retransmission limit
     bool m_isFailedSession;
+    /// Whether the send session has been completed, used to prevent against multiple executions of the session completion procedure
     bool m_calledCancelledOrCompletedCallback;
 };
 

--- a/common/ltp/include/LtpTimerManager.h
+++ b/common/ltp/include/LtpTimerManager.h
@@ -38,53 +38,166 @@ class LtpTimerManager : private boost::noncopyable {
 private:
     LtpTimerManager() = delete;
 public:
+    /**
+     * @typdef LtpTimerExpiredCallback_t Type of callback to be invoked on timer expiry.
+     */
     typedef boost::function<void(void * classPtr, const idType & serialNumber, std::vector<uint8_t> & userData)> LtpTimerExpiredCallback_t;
+    
+    /**
+     * Reserve space for hashMapNumBuckets timers.
+     * Call LtpTimerManager::Reset() to prepare the timer manager.
+     * @param deadlineTimerRef Our managed timer.
+     * @param transmissionToAckReceivedTimeRef The timer wait duration.
+     * @param hashMapNumBuckets The number of queued timers to reserve.
+     */
     LTP_LIB_EXPORT LtpTimerManager(boost::asio::deadline_timer & deadlineTimerRef,
         boost::posix_time::time_duration & transmissionToAckReceivedTimeRef,
         const uint64_t hashMapNumBuckets);
+    
+    /**
+     * If timer manager is NOT active, delete m_timerIsDeletedPtr and set to NULL.
+     * Else, set *m_timerIsDeletedPtr to True and let the current active timer completion handler delete it.
+     *
+     * Call LtpTimerManager::Reset() to release all managed resources.
+     * @post Assumes external code will handle deleting m_timerIsDeletedPtr to prevent a memory leak.
+     */
     LTP_LIB_EXPORT ~LtpTimerManager();
+    
+    /** Perform timer manager reset.
+     *
+     * Clears queued timers, cancels current active timer, then sets timer manager state to inactive.
+     * @post The object is ready to be reused.
+     */
     LTP_LIB_EXPORT void Reset();
-       
+    
+    /** Queue a new timer to manage.
+     *
+     * If a timer associated with serialNumber already exists, returns immediately.
+     * Else, queues a new timer for processing, and if the timer manager is inactive (thus timer queue empty) sets the manager to active and actively
+     * waits on the newly queued timer by starting the managed timer asynchronously with LtpTimerManager::OnTimerExpired() as a completion handler.
+     * @param classPtr Type-erased data pointer.
+     * @param serialNumber The serial number associated with the timer.
+     * @param callbackPtr The callback to invoke on timer expiry.
+     * @param userData The attached user data.
+     * @return True if a NEW timer was queued successfully, or False otherwise.
+     */
     LTP_LIB_EXPORT bool StartTimer(void* classPtr, const idType serialNumber, const LtpTimerExpiredCallback_t* callbackPtr, std::vector<uint8_t> userData = std::vector<uint8_t>());
+    
+    /** Delete a queued timer.
+     *
+     * Calls DeleteTimer(serialNumber, userDataReturned, callbackPtrReturned, classPtrReturned) to delete the queued timer.
+     * On successful deletion, discards all of the timer context data.
+     * @param serialNumber The serial number associated with the timer to delete.
+     * @return True if the timer exists and could be deleted successfully, or False otherwise.
+     */
     LTP_LIB_EXPORT bool DeleteTimer(const idType serialNumber);
+    
+    /** Delete a queued timer.
+     *
+     * Calls DeleteTimer(serialNumber, userDataReturned, callbackPtrReturned, classPtrReturned) to delete the queued timer.
+     * On successful deletion, returns the attached user data to the caller from the timer context data.
+     * @param serialNumber The serial number associated with the timer to delete.
+     * @param userDataReturned The attached user data of the timer.
+     * @return True if the timer exists and could be deleted successfully, or False otherwise.
+     */
     LTP_LIB_EXPORT bool DeleteTimer(const idType serialNumber, std::vector<uint8_t> & userDataReturned);
+    
+    /** Delete a queued timer.
+     *
+     * If a timer associated with serialNumber does NOT exist, returns immediately.
+     * Else, deletes the queued timer from the queue (without cancelling for performance reasons), then sets m_activeSerialNumberBeingTimed to 0.
+     *
+     * On successful deletion, returns the attached user data and the callback and the type-erased data pointer from the timer context data.
+     * @param serialNumber The serial number associated with the timer to delete.
+     * @param userDataReturned The attached user data of the timer.
+     * @param callbackPtrReturned The callback of the timer.
+     * @param classPtrReturned The type-erased data pointer of the timer.
+     * @return True if the timer exists and could be deleted successfully, or False otherwise.
+     */
     LTP_LIB_EXPORT bool DeleteTimer(const idType serialNumber, std::vector<uint8_t> & userDataReturned,
         const LtpTimerExpiredCallback_t*& callbackPtrReturned, void*& classPtrReturned);
+    
+    /** Adjust timer wait duration across all current and future queued timers.
+     *
+     * If the timer manager is NOT active, returns immediately.
+     * Else, adjusts all queued timers by the given difference.
+     * @param diffNewMinusOld The difference from the current timer wait duration, should be a negative duration when new duration < current duration.
+     */
     LTP_LIB_EXPORT void AdjustRunningTimers(const boost::posix_time::time_duration & diffNewMinusOld);
+    
+    /** Query whether the timer queue is empty.
+     *
+     * @return True if the timer queue is empty, or False otherwise.
+     */
     LTP_LIB_EXPORT bool Empty() const;
+    
+    /** Get the timer wait duration.
+     *
+     * @return The timer wait duration.
+     */
     LTP_LIB_EXPORT const boost::posix_time::time_duration& GetTimeDurationRef() const;
     //std::vector<uint8_t> & GetUserDataRef(const uint64_t serialNumber);
 private:
+    /** Handle managed timer expiry.
+     *
+     * If the timer manager is due deletion, deletes isTimerDeleted and returns immediately.
+     * If the expiry did NOT occur due to the timer being manually cancelled, caches the timer context data, calls LtpTimerManager::DeleteTimer() to delete
+     * the expired timer and retain any data the caller might want back, then invokes the timer callback.
+     *
+     * Regardless of the reason the expiration occurred:
+     * If there are any more timers left in the queue, starts the managed timer, for the next timer in the queue, asynchronously with itself
+     * as a completion handler to achieve a processing loop.
+     * Else, sets the timer manager as inactive since there is no more work left to do.
+     * @param e The error code.
+     * @param isTimerDeleted Pointer indicating whether the time manager has been deleted (see m_timerIsDeletedPtr docs for how to handle).
+     */
     LTP_LIB_NO_EXPORT void OnTimerExpired(const boost::system::error_code& e, bool * isTimerDeleted);
 private:
+    /// Our managed timer
     boost::asio::deadline_timer & m_deadlineTimerRef;
-    boost::posix_time::time_duration & m_transmissionToAckReceivedTimeRef; //may be changed from outside
+    /// Timer wait duration, can be adjusted from outside this class
+    boost::posix_time::time_duration & m_transmissionToAckReceivedTimeRef;
     //boost::bimap<idType, boost::posix_time::ptime> m_bimapCheckpointSerialNumberToExpiry;
     //std::map<idType, std::vector<uint8_t> > m_mapSerialNumberToUserData;
+    /// Timer context data
     struct timer_data_t {
+        /// Type-erased data pointer, fed to m_callbackPtr
         void* m_classPtr;
+        /// Associated timer ID
         idType m_id;
+        /// Associated timer expiry
         boost::posix_time::ptime m_expiry;
+        /// Associated timer callback
         const LtpTimerExpiredCallback_t * m_callbackPtr;
+        /// Attached user data
         std::vector<uint8_t> m_userData;
 
         timer_data_t() = delete;
-        //a move constructor: X(X&&)
-        timer_data_t(void* classPtr, idType id, const boost::posix_time::ptime& expiry, const LtpTimerExpiredCallback_t* callbackPtr, std::vector<uint8_t>&& userData) :
+        /// Move constructor
+        timer_data_t(void* classPtr, idType id, const boost::posix_time::ptime& expiry, const LtpTimerExpiredCallback_t* callbackPtr, std::vector<uint8_t>&& userData) : //a move constructor: X(X&&)
             m_classPtr(classPtr),
             m_id(id),
             m_expiry(expiry),
             m_callbackPtr(callbackPtr),
             m_userData(std::move(userData)) {}
     };
+    /// Type of list holding timer context data
     typedef std::list<timer_data_t> timer_data_list_t;
+    /// Type of map holding timer context data iterators, mapped by idType, hashed by hashType
     typedef std::unordered_map<idType, typename timer_data_list_t::iterator, hashType> id_to_data_map_t;
+    /// Timer context data queue
     timer_data_list_t m_listTimerData;
+    /// Timer context data iterators referencing m_listTimerData, mapped by idType
     id_to_data_map_t m_mapIdToTimerData;
     
-
+    
+    /// Serial number of current active timer, when set to 0 indicates no current active timer since a zero serial number is unreachable
     idType m_activeSerialNumberBeingTimed;
+    /// Whether the timer manager is active
     bool m_isTimerActive;
+    /// Timer manager deleted pointer, whether the timer manager has been destructed.
+    /// 1. NULL -> Timer manager has been destructed while NOT active, no further action needed.
+    /// 2. non-NULL AND (*m_timerIsDeletedPtr == true) -> Timer manager has been destructed while active, if observed through timer callback delete pointer and return immediately.
     bool * m_timerIsDeletedPtr;
 };
 

--- a/common/ltp/include/LtpUdpEngine.h
+++ b/common/ltp/include/LtpUdpEngine.h
@@ -108,24 +108,24 @@ private:
      */
     LTP_LIB_NO_EXPORT virtual void PacketInFullyProcessedCallback(bool success) override;
     
-    /** Initiate a UDP send operation for a single packet. //TODO: Docs, complete
+    /** Initiate a UDP send operation for a single packet.
      *
      * Initiates an asynchronous send operation with LtpUdpEngine::HandleUdpSend() as a completion handler.
-     * @param constBufferVec
-     * @param underlyingDataToDeleteOnSentCallback
-     * @param underlyingCsDataToDeleteOnSentCallback
+     * @param constBufferVec The data buffers to send.
+     * @param underlyingDataToDeleteOnSentCallback The underlying data buffers shared pointer.
+     * @param underlyingCsDataToDeleteOnSentCallback The underlying client service data to send shared pointer.
      * @post The arguments to underlyingDataToDeleteOnSentCallback and underlyingCsDataToDeleteOnSentCallback are left in a moved-from state.
      */
     LTP_LIB_NO_EXPORT virtual void SendPacket(std::vector<boost::asio::const_buffer> & constBufferVec,
         std::shared_ptr<std::vector<std::vector<uint8_t> > > & underlyingDataToDeleteOnSentCallback,
         std::shared_ptr<LtpClientServiceDataToSend>& underlyingCsDataToDeleteOnSentCallback) override;
     
-    /** Handle a UDP send operation. //TODO: Docs, complete
+    /** Handle a UDP send operation.
      *
      * Invoked for single-packet-per-system-call send operations.
      * If successful, signals the underlying LtpEngine that a system call has completed with OnSendPacketsSystemCallCompleted_ThreadSafe().
-     * @param underlyingDataToDeleteOnSentCallback
-     * @param underlyingCsDataToDeleteOnSentCallback
+     * @param underlyingDataToDeleteOnSentCallback The underlying data buffers shared pointer.
+     * @param underlyingCsDataToDeleteOnSentCallback The underlying client service data to send shared pointer.
      * @param error The error code.
      * @param bytes_transferred The number of bytes sent.
      */
@@ -133,26 +133,26 @@ private:
         std::shared_ptr<LtpClientServiceDataToSend>& underlyingCsDataToDeleteOnSentCallback,
         const boost::system::error_code& error, std::size_t bytes_transferred);
     
-    /** Initiate a batch UDP send operation. //TODO: Docs, complete
+    /** Initiate a batch UDP send operation.
      *
      * Queues the packets for a batch send operation with UdpBatchSender::QueueSendPacketsOperation_ThreadSafe().
      * The batch sender instance is configured to use LtpUdpEngine::OnSentPacketsCallback() as a completion handler which will be called once the operation has completed.
-     * @param constBufferVecs
-     * @param underlyingDataToDeleteOnSentCallback
-     * @param underlyingCsDataToDeleteOnSentCallback
+     * @param constBufferVecs The vector of data buffers to send.
+     * @param underlyingDataToDeleteOnSentCallback The vector of underlying data buffers shared pointers.
+     * @param underlyingCsDataToDeleteOnSentCallback The vector of underlying client service data to send shared pointers.
      */
     LTP_LIB_NO_EXPORT virtual void SendPackets(std::vector<std::vector<boost::asio::const_buffer> >& constBufferVecs,
         std::vector<std::shared_ptr<std::vector<std::vector<uint8_t> > > >& underlyingDataToDeleteOnSentCallback,
         std::vector<std::shared_ptr<LtpClientServiceDataToSend> >& underlyingCsDataToDeleteOnSentCallback) override;
     
-    /** Handle a batch UDP send operation. //TODO: Docs, complete
+    /** Handle a batch UDP send operation.
      *
      * Invoked for batch send operations.
      * If successful, signals the underlying LtpEngine that a system call has completed with OnSendPacketsSystemCallCompleted_ThreadSafe().
      * @param success Whether the operation was successful.
-     * @param constBufferVecs
-     * @param underlyingDataToDeleteOnSentCallback
-     * @param underlyingCsDataToDeleteOnSentCallback
+     * @param constBufferVecs The vector of data buffers to send.
+     * @param underlyingDataToDeleteOnSentCallback The vector of underlying data buffers shared pointers.
+     * @param underlyingCsDataToDeleteOnSentCallback The vector of underlying client service data to send shared pointers.
      */
     LTP_LIB_NO_EXPORT void OnSentPacketsCallback(bool success, std::vector<std::vector<boost::asio::const_buffer> >& constBufferVecs,
         std::vector<std::shared_ptr<std::vector<std::vector<uint8_t> > > >& underlyingDataToDeleteOnSentCallback,

--- a/common/ltp/src/LtpFragmentSet.cpp
+++ b/common/ltp/src/LtpFragmentSet.cpp
@@ -118,7 +118,6 @@ bool LtpFragmentSet::SplitReportSegment(const Ltp::report_segment_t & originalTo
     return true;
 }
 
-//return true if the set was modified, false if unmodified
 bool LtpFragmentSet::AddReportSegmentToFragmentSet(std::set<data_fragment_t> & fragmentSet, const Ltp::report_segment_t & reportSegment) {
     const uint64_t lowerBound = reportSegment.lowerBound;
     unsigned int numModified = 0;
@@ -129,7 +128,6 @@ bool LtpFragmentSet::AddReportSegmentToFragmentSet(std::set<data_fragment_t> & f
     return (numModified != 0);
 }
 
-//return true if the set was modified, false if unmodified
 bool LtpFragmentSet::AddReportSegmentToFragmentSetNeedingResent(std::set<data_fragment_t> & fragmentSetNeedingResent, const Ltp::report_segment_t & reportSegment) {
     const std::vector<Ltp::reception_claim_t> & receptionClaims = reportSegment.receptionClaims;
     unsigned int numModified = 0;
@@ -137,9 +135,9 @@ bool LtpFragmentSet::AddReportSegmentToFragmentSetNeedingResent(std::set<data_fr
         return false;
     }
     const uint64_t lowerBound = reportSegment.lowerBound;
-    std::vector<Ltp::reception_claim_t>::const_iterator it = receptionClaims.cbegin();
-    if (it->offset > 0) { //add one
-        numModified += InsertFragment(fragmentSetNeedingResent, data_fragment_t(lowerBound, (lowerBound + it->offset) - 1));
+    std::vector<Ltp::reception_claim_t>::const_iterator firstReceptionClaim = receptionClaims.cbegin();
+    if (firstReceptionClaim->offset > 0) { //add one
+        numModified += InsertFragment(fragmentSetNeedingResent, data_fragment_t(lowerBound, (lowerBound + firstReceptionClaim->offset) - 1));
     }
     //uint64_t nextBeginIndex = lowerBound;
     const Ltp::reception_claim_t * previousReceptionClaim = NULL;

--- a/common/ltp/src/LtpRandomNumberGenerator.cpp
+++ b/common/ltp/src/LtpRandomNumberGenerator.cpp
@@ -66,7 +66,7 @@ uint64_t LtpRandomNumberGenerator::GetRandomSession64(boost::random_device & ran
 }
 //return a ping number with:
 //    - bit 63..56 (8 bits of engineIndex)
-//    - bit 55..0 set to 0xffffff for reserved number deonoting ping
+//    - bit 55..0 set to 0xffffff for reserved number denoting ping
 uint64_t LtpRandomNumberGenerator::GetPingSession64() const {
     static constexpr uint64_t pingReserved = 0xffffffffffffffu;
     const uint64_t randomNumber = pingReserved | ((static_cast<uint64_t>(m_engineIndex)) << 56);
@@ -133,7 +133,7 @@ uint32_t LtpRandomNumberGenerator::GetRandomSession32(boost::random_device & ran
 }
 //return a ping number with:
 //    - bit 31..24 (8 bits of engineIndex)
-//    - bit 23..0 set to 0xffffff for reserved number deonoting ping
+//    - bit 23..0 set to 0xffffff for reserved number denoting ping
 uint32_t LtpRandomNumberGenerator::GetPingSession32() const {
     static constexpr uint64_t pingReserved = 0x00ffffffu;
     const uint64_t randomNumber = pingReserved | ((static_cast<uint64_t>(m_engineIndex)) << 24);

--- a/common/ltp/src/LtpSessionRecreationPreventer.cpp
+++ b/common/ltp/src/LtpSessionRecreationPreventer.cpp
@@ -17,7 +17,7 @@
 
 LtpSessionRecreationPreventer::LtpSessionRecreationPreventer(const uint64_t numReceivedSessionsToRemember) :
     M_NUM_RECEIVED_SESSION_NUMBERS_TO_REMEMBER(numReceivedSessionsToRemember),
-    m_previouslyReceivedSessionNumbersUnorderedSet(numReceivedSessionsToRemember + 10), //intial num buckets to prevent rehash
+    m_previouslyReceivedSessionNumbersUnorderedSet(numReceivedSessionsToRemember + 10), //initial num buckets to prevent rehash
     m_previouslyReceivedSessionNumbersQueueVector(numReceivedSessionsToRemember),
     m_queueIsFull(false),
     m_nextQueueIndex(0)

--- a/common/ltp/src/LtpTimerManager.cpp
+++ b/common/ltp/src/LtpTimerManager.cpp
@@ -44,7 +44,7 @@ LtpTimerManager<idType, hashType>::~LtpTimerManager() {
 
 template <typename idType, typename hashType>
 void LtpTimerManager<idType, hashType>::Reset() {
-    m_listTimerData.clear(); //clear first so cancel doesnt restart the next one
+    m_listTimerData.clear(); //clear first so cancel doesn't restart the next one
     m_mapIdToTimerData.clear();
     m_deadlineTimerRef.cancel();
     m_activeSerialNumberBeingTimed = 0;
@@ -115,7 +115,7 @@ bool LtpTimerManager<idType, hashType>::DeleteTimer(const idType serialNumber, s
 template <typename idType, typename hashType>
 void LtpTimerManager<idType, hashType>::OnTimerExpired(const boost::system::error_code& e, bool * isTimerDeleted) {
 
-    //for that timer that got cancelled by the destructor, it's still going to enter this function.. prevent it from using the deleted member variables
+    //for that timer that got cancelled by the destructor, it's still going to enter this function. prevent it from using the deleted member variables
     if (*isTimerDeleted) {
         delete isTimerDeleted;
         return;
@@ -129,10 +129,10 @@ void LtpTimerManager<idType, hashType>::OnTimerExpired(const boost::system::erro
             const LtpTimerExpiredCallback_t * callbackPtr; //grab before DeleteTimer deletes it
             void* classPtr;
             m_activeSerialNumberBeingTimed = 0; //so DeleteTimer does not try to cancel timer that already expired
-            DeleteTimer(serialNumberThatExpired, userData, callbackPtr, classPtr); //callback function can choose to readd it later
+            DeleteTimer(serialNumberThatExpired, userData, callbackPtr, classPtr); //callback function can choose to read it later
 
             const LtpTimerExpiredCallback_t& callbackRef = *callbackPtr;
-            callbackRef(classPtr, serialNumberThatExpired, userData); //called after DeleteTimer in case callback readds it
+            callbackRef(classPtr, serialNumberThatExpired, userData); //called after DeleteTimer in case callback reads it
         }
     }
 
@@ -158,7 +158,7 @@ void LtpTimerManager<idType, hashType>::AdjustRunningTimers(const boost::posix_t
         for (typename timer_data_list_t::iterator it = m_listTimerData.begin(); it != m_listTimerData.end(); ++it) {
             it->m_expiry += diffNewMinusOld;
         }
-        m_deadlineTimerRef.cancel(); //skips over any DeleteTimer calls within OnTimerExpired and readds the timer from m_listTimerData.begin()
+        m_deadlineTimerRef.cancel(); //skips over any DeleteTimer calls within OnTimerExpired and reads the timer from m_listTimerData.begin()
     }
 }
 

--- a/common/ltp/test/TestLtpEngine.cpp
+++ b/common/ltp/test/TestLtpEngine.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE(LtpEngineTestCase, *boost::unit_test::enabled())
             engineDest(ltpRxCfg, engineIndexForEncodingIntoRandomSessionNumber, false),
             DESIRED_RED_DATA_TO_SEND("The quick brown fox jumps over the lazy dog!"),
             DESIRED_TOO_MUCH_RED_DATA_TO_SEND("The quick brown fox jumps over the lazy dog! 12345678910"),
-            DESIRED_RED_AND_GREEN_DATA_TO_SEND("The quick brown fox jumps over the lazy dog!GGE"), //G=>green data not EOB, E=>green datat EOB
+            DESIRED_RED_AND_GREEN_DATA_TO_SEND("The quick brown fox jumps over the lazy dog!GGE"), //G=>green data not EOB, E=>green data EOB
             DESIRED_FULLY_GREEN_DATA_TO_SEND("GGGGGGGGGGGGGGGGGE")
         {
             engineDest.SetSessionStartCallback(boost::bind(&Test::SessionStartReceiverCallback, this, boost::placeholders::_1));

--- a/common/ltp/test/TestLtpTimerManager.cpp
+++ b/common/ltp/test/TestLtpTimerManager.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(LtpTimerManagerTestCase)
                 m_serialNumbersInCallback.push_back(serialNumber);
                 ++m_numCallbacks;
             }
-            else if (m_testNumber = 2) {
+            else if (m_testNumber == 2) {
                 BOOST_REQUIRE(userData == std::vector<uint8_t>({ 1,2,3 }));
                 m_serialNumbersInCallback.push_back(serialNumber);
                 //std::cout << "sn " << serialNumber << std::endl;
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(LtpTimerManagerTestCase)
             BOOST_REQUIRE(m_desired_serialNumbers == m_serialNumbersInCallback);
         }
 
-        void DoTest2() { //readd serial numbers once
+        void DoTest2() { //read serial numbers once
             m_testNumber = 2;
             m_timerManager.Reset();
             m_ioService.stop();
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(LtpTimerManagerTestCase)
         }
 
         void Test3TimerExpired(/*const boost::system::error_code& e*/) {
-            BOOST_REQUIRE(m_timerManager.DeleteTimer(5)); //keep this call within the ioservice thread
+            BOOST_REQUIRE(m_timerManager.DeleteTimer(5)); //keep this call within the io_service thread
         }
         void DoTest3() { //delete an active timer
             m_testNumber = 1;// 1 is valid
@@ -122,7 +122,7 @@ BOOST_AUTO_TEST_CASE(LtpTimerManagerTestCase)
             BOOST_REQUIRE(m_serialNumbersInCallback == std::vector<uint64_t>({ 10,15 }));
         }
         void Test4TimerExpired(/*const boost::system::error_code& e*/) {
-            BOOST_REQUIRE(m_timerManager.DeleteTimer(10)); //keep this call within the ioservice thread
+            BOOST_REQUIRE(m_timerManager.DeleteTimer(10)); //keep this call within the io_service thread
         }
         void DoTest4() { //delete a non-active timer
             m_testNumber = 1;// 1 is valid
@@ -213,7 +213,7 @@ BOOST_AUTO_TEST_CASE(LtpTimerManagerTestCase)
             BOOST_REQUIRE(m_desired_serialNumbers == m_serialNumbersInCallback);
         }
 
-        void DoTest2() { //readd serial numbers once
+        void DoTest2() { //read serial numbers once
             m_testNumber = 2;
             m_timerManager.Reset();
             m_ioService.stop();
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE(LtpTimerManagerTestCase)
         }
 
         void Test3TimerExpired(/*const boost::system::error_code& e*/) {
-            BOOST_REQUIRE(m_timerManager.DeleteTimer(Ltp::session_id_t(5, 6))); //keep this call within the ioservice thread
+            BOOST_REQUIRE(m_timerManager.DeleteTimer(Ltp::session_id_t(5, 6))); //keep this call within the io_service thread
         }
         void DoTest3() { //delete an active timer
             m_testNumber = 1;// 1 is valid
@@ -256,7 +256,7 @@ BOOST_AUTO_TEST_CASE(LtpTimerManagerTestCase)
             BOOST_REQUIRE(m_serialNumbersInCallback == std::vector<Ltp::session_id_t>({ Ltp::session_id_t(10,11),Ltp::session_id_t(15,16) }));
         }
         void Test4TimerExpired(/*const boost::system::error_code& e*/) {
-            BOOST_REQUIRE(m_timerManager.DeleteTimer(Ltp::session_id_t(10,11))); //keep this call within the ioservice thread
+            BOOST_REQUIRE(m_timerManager.DeleteTimer(Ltp::session_id_t(10,11))); //keep this call within the io_service thread
         }
         void DoTest4() { //delete a non-active timer
             m_testNumber = 1;// 1 is valid
@@ -291,7 +291,7 @@ BOOST_AUTO_TEST_CASE(LtpTimerManagerTestCase)
             m_timerManager.AdjustRunningTimers(diffNewMinusOld);
         }
         void Test5ChangeTimeDown(/*const boost::system::error_code& e*/) {
-            //change RTT from 400ms to 1000ms
+            //change RTT from 1000ms to 400ms
             const boost::posix_time::time_duration oldTransmissionToAckReceivedTime = m_transmissionToAckReceivedTime;
             m_transmissionToAckReceivedTime = boost::posix_time::milliseconds(400); //this variable is referenced by all timers, so new timers will use this new value
             const boost::posix_time::time_duration diffNewMinusOld = m_transmissionToAckReceivedTime - oldTransmissionToAckReceivedTime;

--- a/common/util/include/CircularIndexBufferSingleProducerSingleConsumerConfigurable.h
+++ b/common/util/include/CircularIndexBufferSingleProducerSingleConsumerConfigurable.h
@@ -59,7 +59,7 @@ public:
      * Checks if the next element after end (wrap on overflow) is equal to begin.
      * @return True if the external buffer is full, or False otherwise.
      */
-    bool IsFull() const;
+    bool IsFull() const noexcept;
     
     /** Query whether external buffer is empty.
      *

--- a/common/util/include/CircularIndexBufferSingleProducerSingleConsumerConfigurable.h
+++ b/common/util/include/CircularIndexBufferSingleProducerSingleConsumerConfigurable.h
@@ -43,16 +43,16 @@ public:
      * Set the working size of the external buffer, then initialize begin and end to zero.
      * @param size The working size of the associated external buffer.
      */
-    CircularIndexBufferSingleProducerSingleConsumerConfigurable(unsigned int size);
+    CircularIndexBufferSingleProducerSingleConsumerConfigurable(unsigned int size) noexcept;
     
     /// Default destructor
-    ~CircularIndexBufferSingleProducerSingleConsumerConfigurable();
+    ~CircularIndexBufferSingleProducerSingleConsumerConfigurable() noexcept;
 	
     /** Reset bounds.
      *
      * Set begin and end back to zero.
      */
-    void Init();
+    void Init() noexcept;
     
     /** Query whether external buffer is full.
      *
@@ -66,40 +66,40 @@ public:
      * Checks if begin is equal to end.
      * @return True if the external buffer is empty, or False otherwise.
      */
-    bool IsEmpty() const;
+    bool IsEmpty() const noexcept;
     
     /** Get write index.
      *
      * Indicates the start of a write operation.
      * @return CIRCULAR_INDEX_BUFFER_FULL if buffer is full, else the write index.
      */
-    unsigned int GetIndexForWrite() const;
+    unsigned int GetIndexForWrite() const noexcept;
     
     /** Advance write index.
      *
      * Indicates the completion of the current active write operation, advances end one element forward (wrap on overflow).
      */
-    void CommitWrite();
+    void CommitWrite() noexcept;
     
     /** Get read index.
      *
      * Indicates the start of a read operation.
      * @return CIRCULAR_INDEX_BUFFER_EMPTY if buffer is empty, else the read index.
      */
-    unsigned int GetIndexForRead() const;
+    unsigned int GetIndexForRead() const noexcept;
     
     /** Advance read index.
      *
      * Indicates the completion of the current active read operation, advances begin one element forward (wrap on overflow).
      */
-    void CommitRead();
+    void CommitRead() noexcept;
     
     /** Get the number of active elements in the external buffer.
      *
      * Calculates how many elements exist between begin and end.
      * @return The number of elements in the external buffer that are currently being indexed.
      */
-    unsigned int NumInBuffer() const;
+    unsigned int NumInBuffer() const noexcept;
 
 private:
     /// Begin

--- a/common/util/include/LtpClientServiceDataToSend.h
+++ b/common/util/include/LtpClientServiceDataToSend.h
@@ -163,16 +163,33 @@ private:
     std::size_t m_size;
 };
 
-struct UdpSendPacketInfo : private boost::noncopyable { //TODO: Docs, complete
+/// UDP send operation context data
+struct UdpSendPacketInfo : private boost::noncopyable {
+    /// Data buffers to send, references data from underlyingDataToDeleteOnSentCallback
     std::vector<boost::asio::const_buffer> constBufferVec;
+    /// Underlying data buffers shared pointer, feeds constBufferVec
     std::shared_ptr<std::vector<std::vector<uint8_t> > > underlyingDataToDeleteOnSentCallback;
+    /// Underlying client service data to send shared pointer, holds a copy of the in-memory client service data to send shared pointer
+    /// when reading data from memory, if reading data from disk should be nullptr
     std::shared_ptr<LtpClientServiceDataToSend> underlyingCsDataToDeleteOnSentCallback;
+    /// Deferred disk read, for when reading data to send from disk, in which case memoryBlockId MUST be non-zero
     MemoryInFiles::deferred_read_t deferredRead;
+    /// Session originator engine ID
     uint64_t sessionOriginatorEngineId;
 
+    /// Default constructor
     HDTN_UTIL_EXPORT UdpSendPacketInfo() = default;
+    
+    /// Move constructor
     HDTN_UTIL_EXPORT UdpSendPacketInfo(UdpSendPacketInfo&& o) noexcept; //a move constructor: X(X&&)
+    
+    /// Move assignment operator
     HDTN_UTIL_EXPORT UdpSendPacketInfo& operator=(UdpSendPacketInfo&& o) noexcept; //a move assignment: operator=(X&&)
+    
+    /** Perform reset.
+     *
+     * Clears buffers, resets shared pointers, resets deferred read object.
+     */
     HDTN_UTIL_EXPORT void Reset();
 };
 

--- a/common/util/include/MemoryInFiles.h
+++ b/common/util/include/MemoryInFiles.h
@@ -34,56 +34,212 @@ class MemoryInFiles : private boost::noncopyable {
 private:
     MemoryInFiles() = delete;
 public:
+    /**
+     * @typedef write_memory_handler_t Type of I/O write operation completion handler.
+     */
     typedef boost::function<void()> write_memory_handler_t;
+    
+    /**
+     * @typedef read_memory_handler_t Type of I/O read operation completion handler.
+     */
     typedef boost::function<void(bool success)> read_memory_handler_t;
 
+    /// Deferred read context data
     struct deferred_read_t {
+        /// Set target memory block ID to 0, an ID of 0 is unreachable by normal blocks and reserved for failure reporting
         deferred_read_t() : memoryBlockId(0) {}
+        /// Set target memory block ID to 0
         void Reset() {
             memoryBlockId = 0;
         }
+        /// Target memory block ID
         uint64_t memoryBlockId;
+        /// Target memory block offset
         uint64_t offset;
+        /// Output length in bytes
         uint64_t length;
+        /// Type-erased output begin write pointer
         void* readToThisLocationPtr;
     };
+    
+    /// Deferred write context data
     struct deferred_write_t {
+        /// Target memory block ID
         uint64_t memoryBlockId;
+        /// Target memory block offset
         uint64_t offset;
+        /// Input length in bytes
         uint64_t length;
+        /// Type-erased input begin read pointer
         const void* writeFromThisLocationPtr;
     };
     
+    /**
+     * Initialize PIMPL.
+     * @param ioServiceRef I/O execution context reference.
+     * @param rootStorageDirectory The filesystem root directory, a randomly generated directory will be created inside the root that will be the working directory for this instance.
+     * @param newFileAggregationTimeMs The time window in milliseconds for which write allocations will be redirected to the currently active write file.
+     * @param estimatedMaxAllocatedBlocks The number of memory blocks to reverse space for, this is a soft cap to lessen instances of reallocation, the actual space will be expanded if needed.
+     */
     HDTN_UTIL_EXPORT MemoryInFiles(boost::asio::io_service & ioServiceRef,
         const boost::filesystem::path & rootStorageDirectory, const uint64_t newFileAggregationTimeMs,
         const uint64_t estimatedMaxAllocatedBlocks);
+    
+    /// Default destructor
     HDTN_UTIL_EXPORT ~MemoryInFiles();
 
+    /** Allocate new memory block of at least given size.
+     *
+     * Tries to insert memory block metadata for the memory block, if succeeds then calls MemoryBlockInfo::Resize() to perform the allocation.
+     * @param totalSize The minimum number of bytes to fit
+     * @return The memory block ID to the newly created memory block on successful allocation, or 0 if the allocation failed.
+     */
     HDTN_UTIL_EXPORT uint64_t AllocateNewWriteMemoryBlock(uint64_t totalSize);
+    
+    /** Get the size of the given memory block.
+     *
+     * If the given memory block ID does not reference a valid memory block, returns immediately with a value of 0.
+     * Else, returns the allocation size in bytes of the memory block.
+     * @param memoryBlockId The memory block ID.
+     * @return The allocation size of the memory block on successful retrieval, or 0 if retrieval failed.
+     */
     HDTN_UTIL_EXPORT uint64_t GetSizeOfMemoryBlock(const uint64_t memoryBlockId) const noexcept;
+    
+    /** Resize the given memory block.
+     *
+     * If the given memory block ID does not reference a valid memory block, returns immediately with a value of 0.
+     * Else, calls MemoryBlockInfo::Resize() to perform the resize.
+     * @param memoryBlockId The memory block ID.
+     * @param newSize The minimum number of bytes to fit.
+     * @return The total size in bytes of the newly resized allocation on successful resize, or 0 if the resize failed.
+     */
     HDTN_UTIL_EXPORT uint64_t Resize(const uint64_t memoryBlockId, uint64_t newSize);
+    
+    /** Delete the given memory block.
+     *
+     * If the given memory block ID does not reference a valid memory block, returns immediately.
+     *
+     * if the memory block has pending I/O operations queued, then if not already marked, marks the block as due deletion (deferred for after the I/O
+     * operations have been completed, deferred deletion is eventually handled by Impl::ForceDeleteMemoryBlock()).
+     * Else, deletes the memory block.
+     * @param memoryBlockId The memory block ID.
+     * @return True if the memory block was JUST NOW marked as due deletion or was JUST NOW deleted, or False otherwise.
+     */
     HDTN_UTIL_EXPORT bool DeleteMemoryBlock(const uint64_t memoryBlockId);
+    
+    /** Initiate a request to delete the given memory block.
+     *
+     * Initiates an asynchronous request to Impl::HandleAsyncDeleteMemoryBlock() to delete the memory block.
+     * @param memoryBlockId The memory block ID.
+     */
     HDTN_UTIL_EXPORT void AsyncDeleteMemoryBlock(const uint64_t memoryBlockId);
+    
     //returns memoryBlockId (key) assigned to the written data, use that key to read it back
+    
+    /** Initiate deferred single-write operation.
+     *
+     * If the given memory block ID does not reference a valid memory block, returns immediately.
+     * Else, calls MemoryBlockInfo::DoWriteOrRead() to initiate the deferred write operation.
+     * @param deferredWrite The deferred write context data.
+     * @param handlerPtr The completion handler pointer.
+     * @return True if the write operation was queued successfully, or False otherwise.
+     */
     HDTN_UTIL_EXPORT bool WriteMemoryAsync(const deferred_write_t& deferredWrite, const write_memory_handler_t& handler);
+    
+    /** Initiate deferred single-write operation.
+     *
+     * If the given memory block ID does not reference a valid memory block, returns immediately.
+     * Else, calls MemoryBlockInfo::DoWriteOrRead() to initiate the deferred write operation.
+     * @param deferredWrite The deferred write context data.
+     * @param handlerPtr The completion handler pointer.
+     * @return True if the write operation was queued successfully, or False otherwise.
+     * @post The argument to handler is left in a moved-from state.
+     */
     HDTN_UTIL_EXPORT bool WriteMemoryAsync(const deferred_write_t& deferredWrite, write_memory_handler_t&& handler);
+    
+    /** Initiate deferred multi-write operation.
+     *
+     * Calls Impl::WriteMemoryAsync() for every operation in the vector.
+     * @param deferredWritesVec The deferred write context data vector.
+     * @param handlerPtr The completion handler pointer.
+     * @return True if ALL the write operations in the vector could be queued successfully, or False otherwise.
+     */
     HDTN_UTIL_EXPORT bool WriteMemoryAsync(const std::vector<deferred_write_t>& deferredWritesVec, const write_memory_handler_t& handler);
+    
+    /** Initiate deferred multi-write operation.
+     *
+     * Calls Impl::WriteMemoryAsync() for every operation in the vector.
+     * @param deferredWritesVec The deferred write context data vector.
+     * @param handlerPtr The completion handler pointer.
+     * @return True if ALL the write operations in the vector could be queued successfully, or False otherwise.
+     * @post The argument to handler is left in a moved-from state.
+     */
     HDTN_UTIL_EXPORT bool WriteMemoryAsync(const std::vector<deferred_write_t>& deferredWritesVec, write_memory_handler_t&& handler);
 
+    /** Initiate deferred single-read operation.
+     *
+     * If the given memory block ID does not reference a valid memory block, returns immediately.
+     * Else, calls MemoryBlockInfo::DoWriteOrRead() to initiate the deferred read operation.
+     * @param deferredRead The deferred read context data.
+     * @param handlerPtr The completion handler pointer.
+     * @return True if the read operation was queued successfully, or False otherwise.
+     */
     HDTN_UTIL_EXPORT bool ReadMemoryAsync(const deferred_read_t& deferredRead, const read_memory_handler_t& handler);
+    
+    /** Initiate deferred single-read operation.
+     *
+     * If the given memory block ID does not reference a valid memory block, returns immediately.
+     * Else, calls MemoryBlockInfo::DoWriteOrRead() to initiate the deferred read operation.
+     * @param deferredRead The deferred read context data.
+     * @param handlerPtr The completion handler pointer.
+     * @return True if the read operation was queued successfully, or False otherwise.
+     * @post The argument to handler is left in a moved-from state.
+     */
     HDTN_UTIL_EXPORT bool ReadMemoryAsync(const deferred_read_t& deferredRead, read_memory_handler_t&& handler);
+    
+    /** Initiate deferred multi-read operation.
+     *
+     * Calls Impl::ReadMemoryAsync() for every operation in the vector.
+     * @param deferredReadsVec The deferred read context data vector.
+     * @param handlerPtr The completion handler pointer.
+     * @return True if ALL the read operations in the vector could be queued successfully, or False otherwise.
+     */
     HDTN_UTIL_EXPORT bool ReadMemoryAsync(const std::vector<deferred_read_t>& deferredReadsVec, const read_memory_handler_t& handler);
+    
+    /** Initiate deferred multi-read operation.
+     *
+     * Calls Impl::ReadMemoryAsync() for every operation in the vector.
+     * @param deferredReadsVec The deferred read context data vector.
+     * @param handlerPtr The completion handler pointer.
+     * @return True if ALL the read operations in the vector could be queued successfully, or False otherwise.
+     * @post The argument to handler is left in a moved-from state.
+     */
     HDTN_UTIL_EXPORT bool ReadMemoryAsync(const std::vector<deferred_read_t>& deferredReadsVec, read_memory_handler_t&& handler);
 
+    /** Get the total number of files created by this instance.
+     *
+     * @return The total number of files created by this instance.
+     */
     HDTN_UTIL_EXPORT uint64_t GetCountTotalFilesCreated() const;
+    
+    /** Get the number of currently active files.
+     *
+     * Active files are ones storing data that still await further processing or are currently in use, when files become inactive they get deleted.
+     * @return The number of currently active files.
+     */
     HDTN_UTIL_EXPORT uint64_t GetCountTotalFilesActive() const;
 
+    /** Get total number of bytes required for smallest memory block to fit given number of bytes.
+     *
+     * @param minimumDesiredBytes The minimum number of bytes to fit.
+     * @return The total number of bytes required for smallest memory block to fit minimumDesiredBytes number of bytes.
+     */
     HDTN_UTIL_EXPORT static uint64_t CeilToNearestBlockMultiple(const uint64_t minimumDesiredBytes);
     
 private:
-    // Internal implementation class
+    /// PIMPL idiom
     struct Impl;
-    // Pointer to the internal implementation
+    /// Pointer to the internal implementation
     std::unique_ptr<Impl> m_pimpl;
 };
 

--- a/common/util/include/UdpBatchSender.h
+++ b/common/util/include/UdpBatchSender.h
@@ -122,13 +122,13 @@ private:
      */
     HDTN_UTIL_NO_EXPORT bool SetEndpointAndReconnect(const std::string& remoteHostname, const uint16_t remotePort);
     
-    /** Perform a packet batch send operation. //TODO: Docs, complete
+    /** Perform a packet batch send operation.
      *
      * Performs a single synchronous batch send operation.
      * After it finishes (successfully or otherwise), the callback stored in m_onSentPacketsCallback (if any) is invoked.
-     * @param constBufferVecs
-     * @param underlyingDataToDeleteOnSentCallbackVec
-     * @param underlyingCsDataToDeleteOnSentCallbackVec
+     * @param constBufferVecs The vector of data buffers to send.
+     * @param underlyingDataToDeleteOnSentCallbackVec The vector of underlying data buffers shared pointer.
+     * @param underlyingCsDataToDeleteOnSentCallbackVec The vector of underlying client service data to send shared pointers.
      * @post The arguments to constBufferVecs, underlyingDataToDeleteOnSentCallbackVec and underlyingCsDataToDeleteOnSentCallbackVec are left in a moved-from state.
      */
     HDTN_UTIL_NO_EXPORT void PerformSendPacketsOperation(

--- a/common/util/src/CircularIndexBufferSingleProducerSingleConsumerConfigurable.cpp
+++ b/common/util/src/CircularIndexBufferSingleProducerSingleConsumerConfigurable.cpp
@@ -16,40 +16,40 @@
 #include <stdint.h>
 
 
-CircularIndexBufferSingleProducerSingleConsumerConfigurable::CircularIndexBufferSingleProducerSingleConsumerConfigurable(unsigned int size) :
+CircularIndexBufferSingleProducerSingleConsumerConfigurable::CircularIndexBufferSingleProducerSingleConsumerConfigurable(unsigned int size) noexcept :
     m_cbStartIndex(0), m_cbEndIndex(0), M_CIRCULAR_INDEX_BUFFER_SIZE(size)
 {
 	
 }
 
-CircularIndexBufferSingleProducerSingleConsumerConfigurable::~CircularIndexBufferSingleProducerSingleConsumerConfigurable() {
+CircularIndexBufferSingleProducerSingleConsumerConfigurable::~CircularIndexBufferSingleProducerSingleConsumerConfigurable() noexcept {
 	
 }
 
-void CircularIndexBufferSingleProducerSingleConsumerConfigurable::Init() {
+void CircularIndexBufferSingleProducerSingleConsumerConfigurable::Init() noexcept {
     m_cbStartIndex = 0;
     m_cbEndIndex = 0;
 }
 
 
-bool CircularIndexBufferSingleProducerSingleConsumerConfigurable::IsFull() const {
+bool CircularIndexBufferSingleProducerSingleConsumerConfigurable::IsFull() const noexcept {
     //return ((m_end + 1) % m_bufferSize) == m_start;
     unsigned int endPlus1 = m_cbEndIndex + 1;
         if (endPlus1 >= M_CIRCULAR_INDEX_BUFFER_SIZE) endPlus1 = 0;
     return (m_cbStartIndex == endPlus1);
 }
 
-bool CircularIndexBufferSingleProducerSingleConsumerConfigurable::IsEmpty() const {
+bool CircularIndexBufferSingleProducerSingleConsumerConfigurable::IsEmpty() const noexcept {
 	return (m_cbEndIndex == m_cbStartIndex);
 }
 
-unsigned int CircularIndexBufferSingleProducerSingleConsumerConfigurable::GetIndexForWrite() const {
+unsigned int CircularIndexBufferSingleProducerSingleConsumerConfigurable::GetIndexForWrite() const noexcept {
 	if (IsFull())
 		return CIRCULAR_INDEX_BUFFER_FULL;
 	return m_cbEndIndex;
 }
 
-void CircularIndexBufferSingleProducerSingleConsumerConfigurable::CommitWrite() {
+void CircularIndexBufferSingleProducerSingleConsumerConfigurable::CommitWrite() noexcept {
 	////if(CircularBufferIsFull())
 	////	return;
 	//m_end = (m_end + 1) % m_bufferSize;
@@ -58,13 +58,13 @@ void CircularIndexBufferSingleProducerSingleConsumerConfigurable::CommitWrite() 
 	m_cbEndIndex = endPlus1;
 }
 
-unsigned int CircularIndexBufferSingleProducerSingleConsumerConfigurable::GetIndexForRead() const {
+unsigned int CircularIndexBufferSingleProducerSingleConsumerConfigurable::GetIndexForRead() const noexcept {
 	if (IsEmpty())
 		return CIRCULAR_INDEX_BUFFER_EMPTY;
 	return m_cbStartIndex;
 }
 
-void CircularIndexBufferSingleProducerSingleConsumerConfigurable::CommitRead() {
+void CircularIndexBufferSingleProducerSingleConsumerConfigurable::CommitRead() noexcept {
 	////if(CircularBufferIsEmpty())
 	////	return;
 	//m_start = (m_start + 1) % m_bufferSize;
@@ -74,7 +74,7 @@ void CircularIndexBufferSingleProducerSingleConsumerConfigurable::CommitRead() {
 	
 }
 
-unsigned int CircularIndexBufferSingleProducerSingleConsumerConfigurable::NumInBuffer() const {
+unsigned int CircularIndexBufferSingleProducerSingleConsumerConfigurable::NumInBuffer() const noexcept {
     unsigned int endIndex = m_cbEndIndex;
     const unsigned int startIndex = m_cbStartIndex;
     if (endIndex < startIndex) {

--- a/common/util/src/FragmentSet.cpp
+++ b/common/util/src/FragmentSet.cpp
@@ -53,17 +53,17 @@ bool FragmentSet::data_fragment_t::GetOverlap(const data_fragment_t& key1, const
     //https://scicomp.stackexchange.com/questions/26258/the-easiest-way-to-find-intersection-of-two-intervals
     //if ( bs>ae or as>be ) { return 0 }
     //if ( y1>x2 or x1>y2 ) { return 0 } //(rewritten)
-    //if ( y1<=x2 AND x1<=y2 ) { intersect=true } //rewriten
+    //if ( y1<=x2 AND x1<=y2 ) { intersect=true } //rewritten
     //if(intersect) {
     //    os=max(as,bs) 
     //    oe=min(ae,be)
     //}
-    const bool interects = ((key2.beginIndex <= key1.endIndex) && (key1.beginIndex <= key2.endIndex));
-    if (interects) {
+    const bool intersects = ((key2.beginIndex <= key1.endIndex) && (key1.beginIndex <= key2.endIndex));
+    if (intersects) {
         overlap.beginIndex = std::max(key1.beginIndex, key2.beginIndex);
         overlap.endIndex = std::min(key1.endIndex, key2.endIndex);
     }
-    return interects;
+    return intersects;
 }
 bool FragmentSet::data_fragment_t::GetOverlap(const data_fragment_t& o, data_fragment_t& overlap) const {
     return GetOverlap(*this, o, overlap);

--- a/common/util/src/MemoryInFiles.cpp
+++ b/common/util/src/MemoryInFiles.cpp
@@ -36,9 +36,13 @@
 
 static constexpr hdtn::Logger::SubProcess subprocess = hdtn::Logger::SubProcess::none;
 
-static constexpr uint64_t BLOCK_SIZE_MULTIPLE = 4096;
+/// Memory block unit size in bytes
+static constexpr uint64_t BLOCK_SIZE_MULTIPLE = 4096; // 4 KiB
+/// Memory block mask
 static constexpr uint64_t BLOCK_SIZE_MULTIPLE_MASK = BLOCK_SIZE_MULTIPLE - 1;
+/// Memory block shift
 static constexpr uint64_t BLOCK_SIZE_MULTIPLE_SHIFT = 12; //(1<<12) == 4096
+
 uint64_t MemoryInFiles::CeilToNearestBlockMultiple(const uint64_t minimumDesiredBytes) {
     //const uint64_t totalBlocksRequired = (minimumDesiredBytes / BLOCK_SIZE_MULTIPLE) + ((minimumDesiredBytes % BLOCK_SIZE_MULTIPLE) == 0 ? 0 : 1);
     const bool addOne = ((minimumDesiredBytes & BLOCK_SIZE_MULTIPLE_MASK) != 0); //((minimumDesiredBytes % BLOCK_SIZE_MULTIPLE) == 0 ? 0 : 1);
@@ -52,47 +56,188 @@ struct MemoryInFiles::Impl : private boost::noncopyable {
     
 
     Impl() = delete;
+    
+    /**
+     * Set counters to 0.
+     * Start memory block IDs from 1 since 0 is reversed for error reporting.
+     * Reserve space for estimatedMaxAllocatedBlocks number of memory blocks.
+     * Create the working directory on disk if it does not exist.
+     * @param ioServiceRef The I/O execution context.
+     * @param workingDirectory The working directory for file I/O.
+     * @param newFileAggregationTimeMs The time window in milliseconds for which write allocations will be redirected to the currently active write file.
+     * @param estimatedMaxAllocatedBlocks The number of memory blocks to reverse space for, this is a soft cap to lessen instances of reallocation, the actual space will be expanded if needed.
+     */
     Impl(boost::asio::io_service& ioServiceRef,
         const boost::filesystem::path& workingDirectory,
         const uint64_t newFileAggregationTimeMs,
         const uint64_t estimatedMaxAllocatedBlocks);
+    
+    /**
+     * Stop timers.
+     * Clear allocated memory blocks.
+     * Delete the working directory from disk.
+     */
     ~Impl();
+    
+    /// ...
     void Stop();
+    
+    /** Allocate new memory block of at least given size.
+     *
+     * Tries to insert memory block metadata for the memory block, if succeeds then calls MemoryBlockInfo::Resize() to perform the allocation.
+     * @param totalSize The minimum number of bytes to fit
+     * @return The memory block ID to the newly created memory block on successful allocation, or 0 if the allocation failed.
+     */
     uint64_t AllocateNewWriteMemoryBlock(uint64_t totalSize);
-    uint64_t Resize(const uint64_t memoryBlockId, uint64_t newSize); //returns the new size
+    
+    /** Resize the given memory block.
+     *
+     * If the given memory block ID does not reference a valid memory block, returns immediately with a value of 0.
+     * Else, calls MemoryBlockInfo::Resize() to perform the resize.
+     * @param memoryBlockId The memory block ID.
+     * @param newSize The minimum number of bytes to fit.
+     * @return The total size in bytes of the newly resized allocation on successful resize, or 0 if the resize failed.
+     */
+    uint64_t Resize(const uint64_t memoryBlockId, uint64_t newSize);
+    
+    /** Get the size of the given memory block.
+     *
+     * If the given memory block ID does not reference a valid memory block, returns immediately with a value of 0.
+     * Else, returns the allocation size in bytes of the memory block.
+     * @param memoryBlockId The memory block ID.
+     * @return The allocation size of the memory block on successful retrieval, or 0 if retrieval failed.
+     */
     uint64_t GetSizeOfMemoryBlock(const uint64_t memoryBlockId) const noexcept;
+    
+    /** Handle deferred deletion of the given memory block.
+     *
+     * Deletes the memory block.
+     * @param memoryBlockId The memory block ID.
+     */
     void ForceDeleteMemoryBlock(const uint64_t memoryBlockId); //intended only for boost::asio::post calls to defer delete when io operations in progress
+    
+    /** Delete the given memory block.
+     *
+     * If the given memory block ID does not reference a valid memory block, returns immediately.
+     *
+     * if the memory block has pending I/O operations queued, then if not already marked, marks the block as due deletion (deferred for after the I/O
+     * operations have been completed, deferred deletion is eventually handled by Impl::ForceDeleteMemoryBlock()).
+     * Else, deletes the memory block.
+     * @param memoryBlockId The memory block ID.
+     * @return True if the memory block was JUST NOW marked as due deletion or was JUST NOW deleted, or False otherwise.
+     */
     bool DeleteMemoryBlock(const uint64_t memoryBlockId);
+    
+    /** Initiate a request to delete the given memory block.
+     *
+     * Initiates an asynchronous request to Impl::HandleAsyncDeleteMemoryBlock() to delete the memory block.
+     * @param memoryBlockId The memory block ID.
+     */
     void AsyncDeleteMemoryBlock(const uint64_t memoryBlockId);
+    
+    /** Initiate deferred single-write operation.
+     *
+     * If the given memory block ID does not reference a valid memory block, returns immediately.
+     * Else, calls MemoryBlockInfo::DoWriteOrRead() to initiate the deferred write operation.
+     * @param deferredWrite The deferred write context data.
+     * @param handlerPtr The completion handler pointer.
+     * @return True if the write operation was queued successfully, or False otherwise.
+     */
     bool WriteMemoryAsync(const deferred_write_t& deferredWrite, std::shared_ptr<write_memory_handler_t>& handlerPtr);
+    
+    /** Initiate deferred multi-write operation.
+     *
+     * Calls Impl::WriteMemoryAsync() for every operation in the vector.
+     * @param deferredWritesVec The deferred write context data vector.
+     * @param handlerPtr The completion handler pointer.
+     * @return True if ALL the write operations in the vector could be queued successfully, or False otherwise.
+     */
     bool WriteMemoryAsync(const std::vector<deferred_write_t>& deferredWritesVec, std::shared_ptr<write_memory_handler_t>& handlerPtr);
+    
+    /** Initiate deferred single-read operation.
+     *
+     * If the given memory block ID does not reference a valid memory block, returns immediately.
+     * Else, calls MemoryBlockInfo::DoWriteOrRead() to initiate the deferred read operation.
+     * @param deferredRead The deferred read context data.
+     * @param handlerPtr The completion handler pointer.
+     * @return True if the read operation was queued successfully, or False otherwise.
+     */
     bool ReadMemoryAsync(const deferred_read_t& deferredRead, std::shared_ptr<read_memory_handler_t>& handlerPtr);
+    
+    /** Initiate deferred multi-read operation.
+     *
+     * Calls Impl::ReadMemoryAsync() for every operation in the vector.
+     * @param deferredReadsVec The deferred read context data vector.
+     * @param handlerPtr The completion handler pointer.
+     * @return True if ALL the read operations in the vector could be queued successfully, or False otherwise.
+     */
     bool ReadMemoryAsync(const std::vector<deferred_read_t>& deferredReadsVec, std::shared_ptr<read_memory_handler_t>& handlerPtr);
 
 private:
-    void HandleAsyncDeleteMemoryBlock(const uint64_t memoryBlockId); //to print messages if error
+    /** handle deletion of the given memory block.
+     *
+     * Used for logging purposes.
+     * @param memoryBlockId The memory block ID.
+     */
+    void HandleAsyncDeleteMemoryBlock(const uint64_t memoryBlockId);
 
+    /// Forward declaration
     struct MemoryBlockInfo;
-    uint64_t Resize(MemoryBlockInfo& mbi, uint64_t newSize); //returns the new size
+    
+    /** Resize the given memory block.
+     *
+     * If the currently active write file is not operational, returns immediately.
+     * Else, calls MemoryInFiles::CeilToNearestBlockMultiple() to get the new allocation length and then calls MemoryBlockInfo::Resize() to perform the resize.
+     * @param mbi The associated memory block metadata.
+     * @param newSize The minimum number of bytes to fit.
+     * @return The increase in size (NOT the total size of the new allocation) if resizing to a larger length, or 0 if the new length is smaller than the current length.
+     */
+    uint64_t Resize(MemoryBlockInfo& mbi, uint64_t newSize);
+    
+    /** Setup next active file if none is currently active.
+     *
+     * If there is an active write file (we are inside an active write window), returns immediately.
+     * Else, creates a new write file on disk, then starts the active write window timer.
+     * @return True if A write file (either existing or newly created) is now active and ready to be operated on, or False otherwise.
+     * @post If returns True, the active write file is ready to be operated on.
+     */
     bool SetupNextFileIfNeeded();
 
 #ifdef _WIN32
+    /// System file handle
     typedef boost::asio::windows::random_access_handle file_handle_t;
 #else
+    /// System file handle
     typedef boost::asio::posix::stream_descriptor file_handle_t;
 #endif
 
     
 
+    /// I/O operation context data
     struct io_operation_t : private boost::noncopyable {
         io_operation_t() = delete;
+        /**
+         * Set m_readToThisLocationPtr to NULL.
+         * @param memoryBlockInfoRef The associated memory block.
+         * @param offsetWithinFile The file offset to begin operating on.
+         * @param length The data length to operate on.
+         * @param writeLocationPtr The input begin pointer to read from.
+         * @param writeHandlerPtr The I/O write operation completion handler.
+         */
         io_operation_t(
             MemoryBlockInfo& memoryBlockInfoRef,
             uint64_t offsetWithinFile,
             uint64_t length,
             const void* writeLocationPtr,
             std::shared_ptr<write_memory_handler_t>& writeHandlerPtr);
-
+        /**
+         * Set m_writeFromThisLocationPtr to NULL.
+         * @param memoryBlockInfoRef The associated memory block.
+         * @param readHandlerPtr The I/O read operation completion handler.
+         * @param offsetWithinFile The file offset to begin operating on.
+         * @param length The data length to operate on.
+         * @param readLocationPtr The output begin pointer to read into.
+         */
         io_operation_t(
             MemoryBlockInfo& memoryBlockInfoRef,
             std::shared_ptr<read_memory_handler_t>& readHandlerPtr,
@@ -100,80 +245,219 @@ private:
             uint64_t length,
             void* readLocationPtr);
 
+        /// Associated memory block reference
         MemoryBlockInfo& m_memoryBlockInfoRef; //references to unordered_map never get invalidated, only iterators
+        /// File offset to begin operating on
         uint64_t m_offsetWithinFile;
+        /// Data length in bytes to operate on
         uint64_t m_length;
+        /// Type-erased output begin pointer in case of read, NULL on write
         void* m_readToThisLocationPtr;
+        /// Type-erased input begin pointer in case of read, NULL on read
         const void* m_writeFromThisLocationPtr;
+        /// Read operation completion handler shared pointer, one copy per operation for multi-read operations, nullptr on write
         std::shared_ptr<read_memory_handler_t> m_readHandlerPtr;
+        /// Write operation completion handler shared pointer, one copy per operation for multi-write operations, nullptr on read
         std::shared_ptr<write_memory_handler_t> m_writeHandlerPtr;
     };
 
     struct FileInfo : private boost::noncopyable {
         FileInfo() = delete;
+        /**
+         * @param filePath The filesystem path to the associated file.
+         * @param ioServiceRef The I/O execution context.
+         * @param implRef PIMPL reference.
+         */
         FileInfo(const boost::filesystem::path& filePath, boost::asio::io_service & ioServiceRef, MemoryInFiles::Impl& implRef);
+        /**
+         * Cleans up any open system file resources and deletes the associated file from disk.
+         * @post Decrements the pending I/O operation reference counter (m_queuedOperationsReferenceCount).
+         */
         ~FileInfo();
+        /** Try queuing an asynchronous I/O write operation.
+         * If the file is NOT open and ready to be operated on, returns immediately.
+         * Else, queues a new I/O operation, increments the pending I/O operation reference counter, then calls FileInfo::TryStartNextQueuedIoOperation()
+         * to trigger processing of the next queued I/O operation.
+         * @param memoryBlockInfoRef The associated memory block.
+         * @param offsetWithinFile The file offset to begin writing to.
+         * @param data Type-erased input begin pointer to read from.
+         * @param length The data length in bytes to write.
+         * @param handlerPtr Type-erased I/O completion handler pointer.
+         * @return True if the file is open and ready to be operated on, or False otherwise.
+         * @post MIGHT increment the pending I/O operation reference counter (m_queuedOperationsReferenceCount).
+         */
         bool WriteMemoryAsync(MemoryBlockInfo& memoryBlockInfoRef, const uint64_t offsetWithinFile, const void* data, uint64_t length, std::shared_ptr<write_memory_handler_t>& handlerPtr);
+        /** Try queuing an asynchronous I/O read operation.
+         * If the file is NOT open and ready to be operated on, returns immediately.
+         * Else, queues a new I/O operation, increments the pending I/O operation reference counter, then calls FileInfo::TryStartNextQueuedIoOperation()
+         * to trigger processing of the next queued I/O operation.
+         * @param memoryBlockInfoRef The associated memory block.
+         * @param offsetWithinFile The file offset to begin reading from.
+         * @param data Type-erased output begin pointer to read into.
+         * @param length The data length in bytes to read.
+         * @param handlerPtr Type-erased I/O completion handler pointer.
+         * @return True if the file is open and ready to be operated on, or False otherwise.
+         * @post MIGHT increment the pending I/O operation reference counter (m_queuedOperationsReferenceCount).
+         */
         bool ReadMemoryAsync(MemoryBlockInfo& memoryBlockInfoRef, const uint64_t offsetWithinFile, void* data, uint64_t length, std::shared_ptr<read_memory_handler_t>& handlerPtr);
     private:
+        /** Handle completion of a system write operation.
+         * If this is the last component of a multi-write operation, calls the final I/O operation handler (io_operation_t::m_writeHandlerPtr) (if any).
+         * ALWAYS calls FileInfo::FinishCompletionHandler() to finalize the completion of the I/O operation.
+         * @param error The error code.
+         * @param bytes_transferred The number of bytes written.
+         */
         void HandleDiskWriteCompleted(const boost::system::error_code& error, std::size_t bytes_transferred);
+        /** Handle completion of a system read operation.
+         * If this is the last component of a multi-read operation, calls the final I/O operation handler (io_operation_t::m_readHandlerPtr) (if any).
+         * ALWAYS calls FileInfo::FinishCompletionHandler() to finalize the completion of the I/O operation.
+         * @param error The error code.
+         * @param bytes_transferred The number of bytes read.
+         */
         void HandleDiskReadCompleted(const boost::system::error_code& error, std::size_t bytes_transferred);
+        /** Finalize completion of the given I/O operation.
+         * If the associated memory block is due deletion and there are no pending I/O operations left, initiates an asynchronous request to Impl::ForceDeleteMemoryBlock()
+         * to clean up the memory block.
+         * Calls FileInfo::TryStartNextQueuedIoOperation() to trigger processing of the next queued I/O operation.
+         * @param op The completed I/O operation.
+         * @post Decrements the pending I/O operation reference counter (m_queuedOperationsReferenceCount).
+         */
         void FinishCompletionHandler(io_operation_t& op);
+        /** Try start next I/O operation.
+         * If there are no queued operations left or an operation is currently in progress, returns immediately.
+         * Else, acts accordingly to the following cases:
+         * 1. For read operations, initiates an asynchronous system read operation with FileInfo::HandleDiskReadCompleted() as a completion handler.
+         * 2. For write operations, initiates an asynchronous system write operation with FileInfo::HandleDiskWriteCompleted() as a completion handler.
+         */
         void TryStartNextQueuedIoOperation();
         
         
+        /// I/O operation queue
         std::queue<io_operation_t> m_queueIoOperations;
+        /// Pointer to the underlying system file handle
         std::unique_ptr<file_handle_t> m_fileHandlePtr;
+        /// Filesystem path to the associated file
         boost::filesystem::path m_filePath;
+        /// PIMPL reference
         MemoryInFiles::Impl& m_implRef;
+        /// Whether an I/O operation is currently in progress
         bool m_diskOperationInProgress;
+        /// Whether the associated file is open and ready to be operated on
         bool m_valid;
     };
 
+    /// Memory block fragment metadata
     struct MemoryBlockFragmentInfo : private boost::noncopyable {
         MemoryBlockFragmentInfo() = delete;
+        /**
+         * Initialize metadata.
+         * @param fileInfoPtr The file shared pointer.
+         * @param baseOffsetWithinFile The memory block fragment file offset.
+         * @param lengthAlignedToBlockSize The memory block fragment length in bytes.
+         */
         MemoryBlockFragmentInfo(const std::shared_ptr<FileInfo>& fileInfoPtr, const uint64_t baseOffsetWithinFile, const uint64_t lengthAlignedToBlockSize);
+        /// File metadata shared pointer, when all fragments in a file go out of scope the file can then be safely deleted to reclaim disk space
         std::shared_ptr<FileInfo> m_fileInfoPtr;
+        /// Memory block fragment file offset
         const uint64_t m_baseOffsetWithinFile;
+        /// Memory block fragment length in bytes
         const uint64_t m_length;
     };
 
+    /// Memory block metadata
     struct MemoryBlockInfo : private boost::noncopyable {
         MemoryBlockInfo() = delete;
+        /**
+         * Set the memory block ID.
+         * @param memoryBlockId The memory block ID.
+         */
         MemoryBlockInfo(const uint64_t memoryBlockId);
+        /** Resize this memory block.
+         * If new length is smaller than the current length, returns immediately with a value of 0.
+         * Else, on the current active write file creates a new fragment that covers the length difference, thus expanding this memory block by the desired amount.
+         * @param currentFileInfoPtr The current active write file.
+         * @param currentBaseOffsetWithinFile The current active file offset to begin writing from.
+         * @param newLengthAlignedToBlockSize The target memory block length in bytes.
+         * @return The increase in size (NOT the total size of the new allocation) if resizing to a larger length, or 0 if the new length is smaller than the current length.
+         */
         uint64_t Resize(const std::shared_ptr<FileInfo>& currentFileInfoPtr, //returns the increase in size
             const uint64_t currentBaseOffsetWithinFile, const uint64_t newLengthAlignedToBlockSize);
+        /** Initiate a read or write operation.
+         * If the block is due deletion or the data length to operate on exceeds the allocated size of the block, returns immediately.
+         * Else, acts accordingly to the following cases:
+         * 1. When (readToThisLocationPtr == NULL), we are attempting to queue a write operation, calls FileInfo::WriteMemoryAsync() on each eligible fragment.
+         * 2. When (writeFromThisLocationPtr == NULL), we are attempting to queue a read operation, calls FileInfo::ReadMemoryAsync() on each eligible fragment.
+         * Eligible is any fragment that overlaps with the range we are operating on [deferredOffset, (deferredOffset + deferredLength)], as such
+         * if N fragments are eligible, this function will queue N individual I/O operations.
+         * @param deferredOffset The target memory block offset.
+         * @param deferredLength The data length in bytes to read or write.
+         * @param readToThisLocationPtr Type-erased output begin pointer in case of read, NULL on write.
+         * @param writeFromThisLocationPtr Type-erased input begin pointer in case of write, NULL on read.
+         * @param handlerPtrPtr Type-erased I/O completion handler pointer.
+         * @return True if the operation could be queued successfully, or False otherwise.
+         */
         bool DoWriteOrRead(const uint64_t deferredOffset, const uint64_t deferredLength,
             void* readToThisLocationPtr, const void* writeFromThisLocationPtr, void* handlerPtrPtr);
+        /// Memory block ID
         const uint64_t m_memoryBlockId;
+        /// Memory block fragment metadata for all fragments that make up this memory block, the same file may contain multiple fragments and fragments may span multiple files
         ForwardListQueue<MemoryBlockFragmentInfo> m_memoryBlockFragmentInfoFlistQueue;
+        /// Memory block size in bytes, this is the size of the allocation and may differ from the size of the application data currently stored in the block
         uint64_t m_lengthAlignedToBlockSize;
+        /// Pending I/O operations reference counter
         unsigned int m_queuedOperationsReferenceCount;
+        /// Whether the block is due deletion, for graceful cleanup wait until there are no pending I/O operations (m_queuedOperationsReferenceCount == 0)
         bool m_markedForDeletion;
     };
-
+    
+    /** Try restart the active write window timer.
+     *
+     * If the active write window timer is already running, returns immediately.
+     * Else, starts the active write window timer asynchronously with MemoryBlockInfo::OnNewFileAggregation_TimerExpired() as a completion handler.
+     */
     void TryRestartNewFileAggregationTimer();
+    
+    /** Handle active write window timer expiry.
+     *
+     * If the expiry occurred due to the timer being manually cancelled, returns immediately.
+     * Else, resets the currently active write file pointer to prepare for the next write window, it does NOT start the next write window automatically
+     * to prevent periodic empty files from being created during periods where no writes are taking place.
+     * @param e The error code.
+     */
     void OnNewFileAggregation_TimerExpired(const boost::system::error_code& e);
 
+    /// Type of map holding memory block metadata, mapped by memory block ID
     typedef std::unordered_map<uint64_t, MemoryBlockInfo> id_to_memoryblockinfo_map_t;
 
     
 
-
+    /// Memory block metadata for currently allocated memory blocks, mapped by memory block ID
     id_to_memoryblockinfo_map_t m_mapIdToMemoryBlockInfo;
+    /// Currently active write file pointer, the file that will be used during the current active write window
     std::shared_ptr<FileInfo> m_currentWritingFileInfoPtr;
 
+    /// I/O execution context reference
     boost::asio::io_service& m_ioServiceRef;
+    /// Active write window timer, the time window for which write allocations will be redirected to the currently active write file, on expiry (and after the next write) a new file will be created
     boost::asio::deadline_timer m_newFileAggregationTimer;
+    /// Our working directory for file I/O
     const boost::filesystem::path m_rootStorageDirectory;
+    /// Active write window interval in milliseconds, used by m_newFileAggregationTimeDuration
     const uint64_t m_newFileAggregationTimeMs;
+    /// Active write window duration, used by m_newFileAggregationTimer
     const boost::posix_time::time_duration m_newFileAggregationTimeDuration;
+    /// Whether a write window is currently active, will be False on m_newFileAggregationTimer expiry until the next time we queue a write allocation for processing
     bool m_newFileAggregationTimerIsRunning;
+    /// Memory block ID to assign to the next memory block allocated, starts from 1 since memory block ID of 0 is reserved for error reporting
     uint64_t m_nextMemoryBlockId;
+    /// File ID to assign to the next file created
     uint64_t m_nextFileId;
+    /// File offset to begin the next write for the current active write file
     uint64_t m_nextOffsetOfCurrentFile;
 public: //stats
+    /// Total number of files created in the lifetime of the instance
     uint64_t m_countTotalFilesCreated;
+    /// Number of currently active files, active files are ones storing data that still await further processing or are currently in use, when files become inactive they get deleted
     uint64_t m_countTotalFilesActive;
 };
 
@@ -344,7 +628,6 @@ void MemoryInFiles::Impl::FileInfo::FinishCompletionHandler(io_operation_t& op) 
     TryStartNextQueuedIoOperation();
 }
 
-//restarts the token refresh timer if it is not running from now
 void MemoryInFiles::Impl::TryRestartNewFileAggregationTimer() {
     if (!m_newFileAggregationTimerIsRunning) {
         const boost::posix_time::ptime nowPtime = boost::posix_time::microsec_clock::universal_time();


### PR DESCRIPTION
@briantomko For a couple functions with complex branches modeled after the RFC in senders/receivers and the engine, I added docs in pseudocode form to better show the code paths and algorithms implemented, since those kinds of comments would be harder to maintain I used them sparingly, if that's undesirable I could try summarizing them.

Tried keeping the overall format semi-consistent but focused on getting the bulk out of the way, do point out if in any places the documentation is wrong/ambiguous.